### PR TITLE
Implement final properties, lazy evaluation and DMO support

### DIFF
--- a/SO_properties.py
+++ b/SO_properties.py
@@ -1219,7 +1219,11 @@ class SOProperties(HaloProperty):
         # all variables are defined with physical units and an appropriate dtype
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
-        for name, _, shape, dtype, unit, _, _, _ in self.property_list:
+        for prop in self.property_list:
+            name = prop[0]
+            shape = prop[2]
+            dtype = prop[3]
+            unit = prop[4]
             if shape > 1:
                 val = [0] * shape
             else:
@@ -1258,7 +1262,11 @@ class SOProperties(HaloProperty):
 
                 do_calculation = self.category_filter.get_filters(halo_result)
 
-                for name, _, shape, dtype, unit, _, category, _ in self.property_list:
+                for prop in self.property_list:
+                    name = prop[0]
+                    dtype = prop[3]
+                    unit = prop[4]
+                    category = prop[6]
                     if do_calculation[category]:
                         val = getattr(part_props, name)
                         if val is not None:
@@ -1274,7 +1282,10 @@ class SOProperties(HaloProperty):
 
         # Return value should be a dict containing unyt_arrays and descriptions.
         # The dict keys will be used as HDF5 dataset names in the output.
-        for name, outputname, _, _, _, description, _, _ in self.property_list:
+        for prop in self.property_list:
+            name = prop[0]
+            outputname = prop[1]
+            description = prop[5]
             halo_result.update(
                 {
                     f"SO/{self.SO_name}/{outputname}": (
@@ -1498,16 +1509,11 @@ def test_SO_properties():
             assert input_halo_copy == input_halo
             assert input_data_copy == input_data
 
-            for (
-                _,
-                outputname,
-                size,
-                dtype,
-                unit_string,
-                _,
-                _,
-                _,
-            ) in prop_calc.property_list:
+            for prop in prop_calc.property_list:
+                outputname = prop[1]
+                size = prop[2]
+                dtype = prop[3]
+                unit_string = prop[4]
                 full_name = f"SO/{SO_name}/{outputname}"
                 assert full_name in halo_result
                 result = halo_result[full_name][0]

--- a/SO_properties.py
+++ b/SO_properties.py
@@ -947,7 +947,7 @@ def test_SO_properties():
     )
 
     for i in range(100):
-        input_halo, data, rmax, Mtot, Npart = dummy_halos.get_random_halo(
+        input_halo, data, rmax, Mtot, Npart, _ = dummy_halos.get_random_halo(
             [2, 10, 100, 1000, 10000], has_neutrinos=True
         )
         rho_ref = Mtot / (4.0 / 3.0 * np.pi * rmax**3)

--- a/SO_properties.py
+++ b/SO_properties.py
@@ -14,10 +14,23 @@ from kinematic_properties import (
 )
 from recently_heated_gas_filter import RecentlyHeatedGasFilter
 from property_table import PropertyTable
-
 from dataset_names import mass_dataset
+from lazy_properties import lazy_property
 
-from mpi4py import MPI
+
+def set_halo_property(prop_dict, name, part_props):
+    prop_info = PropertyTable.full_property_list[name]
+    dtype = prop_info[2]
+    units = prop_info[3]
+    val = getattr(part_props, name)
+    if val is not None:
+        if units == "dimensionless":
+            prop_dict[name] = unyt.unyt_array(
+                val.astype(dtype), dtype=dtype, units=units
+            )
+        else:
+            prop_dict[name] += val
+
 
 # index of elements O and Fe in the SmoothedElementMassFractions dataset
 indexO = 4
@@ -169,6 +182,833 @@ def find_SO_radius_and_mass(
     return SO_r, SO_mass, SO_volume
 
 
+class SOParticleData:
+    def __init__(
+        self,
+        input_halo,
+        data,
+        types_present,
+        recently_heated_gas_filter,
+        nu_density,
+        observer_position,
+    ):
+        self.input_halo = input_halo
+        self.data = data
+        self.types_present = types_present
+        self.recently_heated_gas_filter = recently_heated_gas_filter
+        self.nu_density = nu_density
+        self.observer_position = observer_position
+        self.compute_basics()
+
+    def compute_basics(self):
+        self.centre = self.input_halo["cofp"]
+        self.index = self.input_halo["index"]
+
+        # Make an array of particle masses, radii and positions
+        mass = []
+        radius = []
+        position = []
+        velocity = []
+        types = []
+        groupnr = []
+        for ptype in self.types_present:
+            if ptype == "PartType6":
+                # add neutrinos separately, since we need to treat them
+                # differently
+                continue
+            mass.append(self.data[ptype][mass_dataset(ptype)])
+            pos = self.data[ptype]["Coordinates"] - self.centre[None, :]
+            position.append(pos)
+            r = np.sqrt(np.sum(pos**2, axis=1))
+            radius.append(r)
+            velocity.append(self.data[ptype]["Velocities"])
+            typearr = np.zeros(r.shape, dtype="U9")
+            typearr[:] = ptype
+            types.append(typearr)
+            groupnr.append(self.data[ptype]["GroupNr_bound"])
+        self.mass = unyt.array.uconcatenate(mass)
+        self.radius = unyt.array.uconcatenate(radius)
+        self.position = unyt.array.uconcatenate(position)
+        self.velocity = unyt.array.uconcatenate(velocity)
+        self.types = np.concatenate(types)
+        self.groupnr = unyt.array.uconcatenate(groupnr)
+
+        # figure out which particles in the list are bound to a halo that is not the
+        # central halo
+        self.is_bound_to_satellite = (self.groupnr >= 0) & (self.groupnr != self.index)
+
+    def compute_SO_radius_and_mass(self, reference_density, physical_radius):
+        # add neutrinos
+        if "PartType6" in self.data:
+            numass = (
+                self.data["PartType6"]["Masses"] * self.data["PartType6"]["Weights"]
+            )
+            pos = self.data["PartType6"]["Coordinates"] - self.centre[None, :]
+            nur = np.sqrt(np.sum(pos**2, axis=1))
+            all_mass = unyt.array.uconcatenate([self.mass, numass])
+            all_r = unyt.array.uconcatenate([self.radius, nur])
+        else:
+            all_mass = self.mass
+            all_r = self.radius
+
+        # Sort by radius
+        order = np.argsort(all_r)
+        ordered_radius = all_r[order]
+        cumulative_mass = np.cumsum(all_mass[order], dtype=np.float64).astype(
+            self.mass.dtype
+        )
+        # add mean neutrino mass
+        cumulative_mass += self.nu_density * 4.0 / 3.0 * np.pi * ordered_radius**3
+
+        # Compute density within radius of each particle.
+        # Will need to skip any at zero radius.
+        # Note that because of the definition of the centre of potential, the first
+        # particle *should* be at r=0. We need to manually exclude it, in case round
+        # off error places it at a very small non-zero radius.
+        nskip = max(1, np.argmax(ordered_radius > 0.0 * ordered_radius.units))
+        ordered_radius = ordered_radius[nskip:]
+        cumulative_mass = cumulative_mass[nskip:]
+        nr_parts = len(ordered_radius)
+        density = cumulative_mass / (4.0 / 3.0 * np.pi * ordered_radius**3)
+
+        # Check if we ever reach the density threshold
+        if reference_density > 0:
+            if nr_parts > 0:
+                try:
+                    self.SO_r, self.SO_mass, self.SO_volume = find_SO_radius_and_mass(
+                        ordered_radius,
+                        density,
+                        cumulative_mass,
+                        reference_density,
+                    )
+                except ReadRadiusTooSmallError:
+                    raise ReadRadiusTooSmallError("SO radius multiple was too small!")
+            else:
+                self.SO_volume = 0 * ordered_radius.units**3
+        elif physical_radius > 0:
+            self.SO_r = physical_radius
+            self.SO_volume = 4.0 * np.pi / 3.0 * self.SO_r**3
+            if nr_parts > 0:
+                # find the enclosed mass using interpolation
+                outside_radius = ordered_radius > self.SO_r
+                if not np.any(outside_radius):
+                    # all particles are within the radius, we cannot interpolate
+                    self.SO_mass = cumulative_mass[-1]
+                else:
+                    i = np.argmax(outside_radius)
+                    if i == 0:
+                        # we only have particles in the centre, so we cannot interpolate
+                        self.SO_mass = cumulative_mass[i]
+                    else:
+                        r1 = ordered_radius[i - 1]
+                        r2 = ordered_radius[i]
+                        M1 = cumulative_mass[i - 1]
+                        M2 = cumulative_mass[i]
+                        self.SO_mass = M1 + (self.SO_r - r1) / (r2 - r1) * (M2 - M1)
+
+        # check if we were successful. We only compute SO properties if we
+        # have both a radius and mass (the mass criterion covers the case where
+        # the radius is set to a physical size but we have no mass nonetheless)
+        SO_exists = self.SO_r > 0 and self.SO_mass > 0
+
+        if SO_exists:
+            self.gas_selection = self.radius[self.types == "PartType0"] < self.SO_r
+            self.dm_selection = self.radius[self.types == "PartType1"] < self.SO_r
+            self.star_selection = self.radius[self.types == "PartType4"] < self.SO_r
+            self.bh_selection = self.radius[self.types == "PartType5"] < self.SO_r
+
+            self.all_selection = self.radius < self.SO_r
+            self.mass = self.mass[self.all_selection]
+            self.radius = self.radius[self.all_selection]
+            self.position = self.position[self.all_selection]
+            self.velocity = self.velocity[self.all_selection]
+            self.types = self.types[self.all_selection]
+            self.is_bound_to_satellite = self.is_bound_to_satellite[self.all_selection]
+
+        return SO_exists
+
+    @property
+    def r(self):
+        return self.SO_r
+
+    @property
+    def Mtot(self):
+        return self.SO_mass
+
+    @lazy_property
+    def Mtotpart(self):
+        return self.mass.sum()
+
+    @lazy_property
+    def mass_fraction(self):
+        # note that we cannot divide by mSO here, since that was based on an interpolation
+        return self.mass / self.Mtotpart
+
+    @lazy_property
+    def com(self):
+        return (self.mass_fraction[:, None] * self.position).sum(axis=0) + self.centre
+
+    @lazy_property
+    def vcom(self):
+        return (self.mass_fraction[:, None] * self.velocity).sum(axis=0)
+
+    @lazy_property
+    def spin_parameter(self):
+        if self.Mtotpart == 0:
+            return None
+        _, vmax = get_vmax(self.mass, self.radius)
+        if vmax > 0:
+            vrel = self.velocity - self.vcom[None, :]
+            Ltot = unyt.array.unorm(
+                (self.mass[:, None] * unyt.array.ucross(self.position, vrel)).sum(
+                    axis=0
+                )
+            )
+            return Ltot / (np.sqrt(2.0) * self.Mtotpart * self.SO_r * vmax)
+        return None
+
+    @lazy_property
+    def TotalAxisLengths(self):
+        if self.Mtotpart == 0:
+            return None
+        return get_axis_lengths(self.mass, self.position)
+
+    @lazy_property
+    def Mfrac_satellites(self):
+        return self.mass[self.is_bound_to_satellite].sum() / self.SO_mass
+
+    @lazy_property
+    def gas_masses(self):
+        return self.mass[self.types == "PartType0"]
+
+    @lazy_property
+    def gas_pos(self):
+        return self.position[self.types == "PartType0"]
+
+    @lazy_property
+    def gas_vel(self):
+        return self.velocity[self.types == "PartType0"]
+
+    @lazy_property
+    def Mgas(self):
+        return self.gas_masses.sum()
+
+    @lazy_property
+    def gas_mass_fraction(self):
+        if self.Mgas == 0:
+            return None
+        return self.gas_masses / self.Mgas
+
+    @lazy_property
+    def com_gas(self):
+        if self.Mgas == 0:
+            return None
+        return (self.gas_mass_fraction[:, None] * self.gas_pos).sum(
+            axis=0
+        ) + self.centre
+
+    @lazy_property
+    def vcom_gas(self):
+        if self.Mgas == 0:
+            return None
+        return (self.gas_mass_fraction[:, None] * self.gas_vel).sum(axis=0)
+
+    def compute_Lgas_props(self):
+        (
+            self.internal_Lgas,
+            _,
+            self.internal_Mcountrot_gas,
+        ) = get_angular_momentum_and_kappa_corot(
+            self.gas_masses,
+            self.gas_pos,
+            self.gas_vel,
+            ref_velocity=self.vcom_gas,
+            do_counterrot_mass=True,
+        )
+
+    @lazy_property
+    def Lgas(self):
+        if self.Mgas == 0:
+            return None
+        if not hasattr(self, "internal_Lgas"):
+            self.compute_Lgas_props()
+        return self.internal_Lgas
+
+    @lazy_property
+    def DtoTgas(self):
+        if self.Mgas == 0:
+            return None
+        if not hasattr(self, "internal_Mcountrot_gas"):
+            self.compute_Lgas_props()
+        return 1.0 - 2.0 * self.internal_Mcountrot_gas / self.Mgas
+
+    @lazy_property
+    def GasAxisLengths(self):
+        if self.Mgas == 0:
+            return None
+        return get_axis_lengths(self.gas_masses, self.gas_pos)
+
+    @lazy_property
+    def dm_masses(self):
+        return self.mass[self.types == "PartType1"]
+
+    @lazy_property
+    def dm_pos(self):
+        return self.position[self.types == "PartType1"]
+
+    @lazy_property
+    def dm_vel(self):
+        return self.velocity[self.types == "PartType1"]
+
+    @lazy_property
+    def Mdm(self):
+        return self.dm_masses.sum()
+
+    @lazy_property
+    def dm_mass_fraction(self):
+        if self.Mdm == 0:
+            return None
+        return self.dm_masses / self.Mdm
+
+    @lazy_property
+    def vcom_dm(self):
+        if self.Mdm == 0:
+            return None
+        return (self.dm_mass_fraction[:, None] * self.dm_vel).sum(axis=0)
+
+    @lazy_property
+    def Ldm(self):
+        if self.Mdm == 0:
+            return None
+        return get_angular_momentum(
+            self.dm_masses, self.dm_pos, self.dm_vel, ref_velocity=self.vcom_dm
+        )
+
+    @lazy_property
+    def DMAxisLengths(self):
+        if self.Mdm == 0:
+            return None
+        return get_axis_lengths(self.dm_masses, self.dm_pos)
+
+    @lazy_property
+    def star_masses(self):
+        return self.mass[self.types == "PartType4"]
+
+    @lazy_property
+    def star_pos(self):
+        return self.position[self.types == "PartType4"]
+
+    @lazy_property
+    def star_vel(self):
+        return self.velocity[self.types == "PartType4"]
+
+    @lazy_property
+    def Mstar(self):
+        return self.star_masses.sum()
+
+    @lazy_property
+    def star_mass_fraction(self):
+        if self.Mstar == 0:
+            return None
+        return self.star_masses / self.Mstar
+
+    @lazy_property
+    def com_star(self):
+        if self.Mstar == 0:
+            return None
+        return (self.star_mass_fraction[:, None] * self.star_pos).sum(
+            axis=0
+        ) + self.centre
+
+    @lazy_property
+    def vcom_star(self):
+        if self.Mstar == 0:
+            return None
+        return (self.star_mass_fraction[:, None] * self.star_vel).sum(axis=0)
+
+    def compute_Lstar_props(self):
+        (
+            self.internal_Lstar,
+            _,
+            self.internal_Mcountrot_star,
+        ) = get_angular_momentum_and_kappa_corot(
+            self.star_masses,
+            self.star_pos,
+            self.star_vel,
+            ref_velocity=self.vcom_star,
+            do_counterrot_mass=True,
+        )
+
+    @lazy_property
+    def Lstar(self):
+        if self.Mstar == 0:
+            return None
+        if not hasattr(self, "internal_Lstar"):
+            self.compute_Lstar_props()
+        return self.internal_Lstar
+
+    @lazy_property
+    def DtoTstar(self):
+        if self.Mstar == 0:
+            return None
+        if not hasattr(self, "internal_Mcountrot_star"):
+            self.compute_Lstar_props()
+        return 1.0 - 2.0 * self.internal_Mcountrot_star / self.Mstar
+
+    @lazy_property
+    def StellarAxisLengths(self):
+        if self.Mstar == 0:
+            return None
+        return get_axis_lengths(self.star_masses, self.star_pos)
+
+    @lazy_property
+    def baryon_masses(self):
+        return self.mass[(self.types == "PartType0") | (self.types == "PartType4")]
+
+    @lazy_property
+    def baryon_pos(self):
+        return self.position[(self.types == "PartType0") | (self.types == "PartType4")]
+
+    @lazy_property
+    def baryon_vel(self):
+        return self.velocity[(self.types == "PartType0") | (self.types == "PartType4")]
+
+    @lazy_property
+    def Mbaryons(self):
+        return self.baryon_masses.sum()
+
+    @lazy_property
+    def baryon_mass_fraction(self):
+        if self.Mbaryons == 0:
+            return None
+        return self.baryon_masses / self.Mbaryons
+
+    @lazy_property
+    def baryon_vcom(self):
+        if self.Mbaryons == 0:
+            return None
+        return (self.baryon_mass_fraction[:, None] * self.baryon_vel).sum(axis=0)
+
+    @lazy_property
+    def Lbaryons(self):
+        if self.Mbaryons == 0:
+            return None
+        baryon_relvel = self.baryon_vel - self.baryon_vcom[None, :]
+        return (
+            self.baryon_masses[:, None]
+            * unyt.array.ucross(self.baryon_pos, baryon_relvel)
+        ).sum(axis=0)
+
+    @lazy_property
+    def BaryonAxisLengths(self):
+        if self.Mbaryons == 0:
+            return None
+        return get_axis_lengths(self.baryon_masses, self.baryon_pos)
+
+    @lazy_property
+    def Mbh_dynamical(self):
+        return self.mass[self.types == "PartType5"].sum()
+
+    @lazy_property
+    def Ngas(self):
+        return self.gas_selection.sum()
+
+    @lazy_property
+    def Mgasmetal(self):
+        if self.Ngas == 0:
+            return None
+        return (
+            self.gas_masses
+            * self.data["PartType0"]["MetalMassFractions"][self.gas_selection]
+        ).sum()
+
+    @lazy_property
+    def MgasO(self):
+        if self.Ngas == 0:
+            return None
+        return (
+            self.gas_masses
+            * self.data["PartType0"]["SmoothedElementMassFractions"][
+                self.gas_selection
+            ][:, indexO]
+        ).sum()
+
+    @lazy_property
+    def MgasFe(self):
+        if self.Ngas == 0:
+            return None
+        return (
+            self.gas_masses
+            * self.data["PartType0"]["SmoothedElementMassFractions"][
+                self.gas_selection
+            ][:, indexFe]
+        ).sum()
+
+    @lazy_property
+    def gas_temperatures(self):
+        if self.Ngas == 0:
+            return None
+        return self.data["PartType0"]["Temperatures"][self.gas_selection]
+
+    @lazy_property
+    def Tgas(self):
+        if self.Ngas == 0:
+            return None
+        return (self.gas_temperatures * (self.gas_masses / self.Mgas)).sum()
+
+    @lazy_property
+    def gas_no_cool(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_temperatures > 1.0e5 * unyt.K
+
+    @lazy_property
+    def Mhotgas(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_masses[self.gas_no_cool].sum()
+
+    @lazy_property
+    def Tgas_no_cool(self):
+        if self.Ngas == 0:
+            return None
+        if np.any(self.gas_no_cool):
+            return (
+                self.gas_temperatures[self.gas_no_cool]
+                * self.gas_masses[self.gas_no_cool]
+            ).sum() / self.Mhotgas
+
+    @lazy_property
+    def SFR(self):
+        if self.Ngas == 0:
+            return None
+        SFR = self.data["PartType0"]["StarFormationRates"][self.gas_selection]
+        is_SFR = SFR > 0.0
+        return SFR[is_SFR].sum()
+
+    @lazy_property
+    def gas_xraylum(self):
+        if self.Ngas == 0:
+            return None
+        return self.data["PartType0"]["XrayLuminosities"][self.gas_selection]
+
+    @lazy_property
+    def Xraylum(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_xraylum.sum()
+
+    @lazy_property
+    def gas_xrayphlum(self):
+        if self.Ngas == 0:
+            return None
+        return self.data["PartType0"]["XrayPhotonLuminosities"][self.gas_selection]
+
+    @lazy_property
+    def Xrayphlum(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_xrayphlum.sum()
+
+    @lazy_property
+    def gas_compY(self):
+        if self.Ngas == 0:
+            return None
+        return self.data["PartType0"]["ComptonYParameters"][self.gas_selection]
+
+    @lazy_property
+    def compY_unit(self):
+        # We need to manually convert the units for compY to avoid numerical
+        # overflow inside unyt
+        if self.Ngas == 0:
+            return None
+        unit = 1.0 * self.gas_compY.units
+        new_unit = unit.to(PropertyTable.full_property_list["compY"][3])
+        return new_unit
+
+    @lazy_property
+    def compY(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_compY.sum().value * self.compY_unit
+
+    @lazy_property
+    def gas_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        last_agn_gas = self.data["PartType0"]["LastAGNFeedbackScaleFactors"][
+            self.gas_selection
+        ]
+        return ~self.recently_heated_gas_filter.is_recently_heated(
+            last_agn_gas, self.gas_temperatures
+        )
+
+    @lazy_property
+    def Xraylum_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_xraylum[self.gas_no_agn].sum()
+
+    @lazy_property
+    def Xrayphlum_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_xrayphlum[self.gas_no_agn].sum()
+
+    @lazy_property
+    def compY_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_compY[self.gas_no_agn].sum().value * self.compY_unit
+
+    @lazy_property
+    def Tgas_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        mass_gas_no_agn = self.gas_masses[self.gas_no_agn]
+        Mgas_no_agn = mass_gas_no_agn.sum()
+        if Mgas_no_agn > 0:
+            return (
+                (mass_gas_no_agn / Mgas_no_agn) * self.gas_temperatures[self.gas_no_agn]
+            ).sum()
+
+    @lazy_property
+    def gas_no_cool_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_no_cool & self.gas_no_agn
+
+    @lazy_property
+    def Tgas_no_cool_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        mass_gas_no_cool_no_agn = self.gas_masses[self.gas_no_cool_no_agn]
+        Mgas_no_cool_no_agn = mass_gas_no_cool_no_agn.sum()
+        if Mgas_no_cool_no_agn > 0:
+            return (
+                (mass_gas_no_cool_no_agn / Mgas_no_cool_no_agn)
+                * self.gas_temperatures[self.gas_no_cool_no_agn]
+            ).sum()
+
+    @lazy_property
+    def Ekin_gas(self):
+        if self.Ngas == 0:
+            return None
+        # below we need to force conversion to np.float64 before summing up particles
+        # to avoid overflow
+        ekin_gas = self.gas_masses * ((self.gas_vel - self.vcom_gas[None, :]) ** 2).sum(
+            axis=1
+        )
+        ekin_gas = unyt.unyt_array(
+            ekin_gas.value, dtype=np.float64, units=ekin_gas.units
+        )
+        return 0.5 * ekin_gas.sum()
+
+    @lazy_property
+    def gas_densities(self):
+        if self.Ngas == 0:
+            return None
+        return self.data["PartType0"]["Densities"][self.gas_selection]
+
+    @lazy_property
+    def Etherm_gas(self):
+        if self.Ngas == 0:
+            return None
+        etherm_gas = (
+            1.5
+            * self.gas_masses
+            * self.data["PartType0"]["Pressures"][self.gas_selection]
+            / self.gas_densities
+        )
+        etherm_gas = unyt.unyt_array(
+            etherm_gas.value, dtype=np.float64, units=etherm_gas.units
+        )
+        return etherm_gas.sum()
+
+    @lazy_property
+    def DopplerB(self):
+        return None
+        if self.Ngas == 0:
+            return None
+        ne = self.data["PartType0"]["ElectronNumberDensities"][self.gas_selection]
+        # note: the positions where relative to the centre, so we have
+        # to make them absolute again before subtracting the observer
+        # position
+        relpos = self.gas_pos + self.centre[None, :] - self.observer_position[None, :]
+        distance = np.sqrt((relpos**2).sum(axis=1))
+        # we need to exclude particles at zero distance
+        # (we assume those have no relative velocity)
+        vr = unyt.unyt_array(
+            np.zeros(self.gas_vel.shape[0]),
+            dtype=self.gas_vel.dtype,
+            units=self.gas_vel.units,
+        )
+        has_distance = distance > 0.0
+        vr[has_distance] = (
+            self.gas_vel[has_distance, 0] * relpos[has_distance, 0]
+            + self.gas_vel[has_distance, 1] * relpos[has_distance, 1]
+            + self.gas_vel[has_distance, 2] * relpos[has_distance, 2]
+        ) / distance[has_distance]
+        fac = unyt.sigma_thompson / unyt.c
+        volumes = self.gas_masses / self.gas_densities
+        area = np.pi * self.SO_r**2
+        return (fac * ne * vr * (volumes / area)).sum()
+
+    @lazy_property
+    def Ndm(self):
+        return self.dm_selection.sum()
+
+    @lazy_property
+    def Nstar(self):
+        return self.star_selection.sum()
+
+    @lazy_property
+    def Mstar_init(self):
+        if self.Nstar == 0:
+            return None
+        return self.data["PartType4"]["InitialMasses"][self.star_selection].sum()
+
+    @lazy_property
+    def Mstarmetal(self):
+        if self.Nstar == 0:
+            return None
+        return (
+            self.star_masses
+            * self.data["PartType4"]["MetalMassFractions"][self.star_selection]
+        ).sum()
+
+    @lazy_property
+    def MstarO(self):
+        if self.Nstar == 0:
+            return None
+        return (
+            self.star_masses
+            * self.data["PartType4"]["SmoothedElementMassFractions"][
+                self.star_selection
+            ][:, indexO]
+        ).sum()
+
+    @lazy_property
+    def MstarFe(self):
+        if self.Nstar == 0:
+            return None
+        return (
+            self.star_masses
+            * self.data["PartType4"]["SmoothedElementMassFractions"][
+                self.star_selection
+            ][:, indexFe]
+        ).sum()
+
+    @lazy_property
+    def StellarLuminosity(self):
+        if self.Nstar == 0:
+            return None
+        return self.data["PartType4"]["Luminosities"][self.star_selection].sum(axis=0)
+
+    @lazy_property
+    def Ekin_star(self):
+        if self.Nstar == 0:
+            return None
+        # below we need to force conversion to np.float64 before summing up particles
+        # to avoid overflow
+        ekin_star = self.star_masses * (
+            (self.star_vel - self.vcom_star[None, :]) ** 2
+        ).sum(axis=1)
+        ekin_star = unyt.unyt_array(
+            ekin_star.value, dtype=np.float64, units=ekin_star.units
+        )
+        return 0.5 * ekin_star.sum()
+
+    @lazy_property
+    def Nbh(self):
+        return self.bh_selection.sum()
+
+    @lazy_property
+    def Mbh_subgrid(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["SubgridMasses"][self.bh_selection].sum()
+
+    @lazy_property
+    def agn_eventa(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["LastAGNFeedbackScaleFactors"][self.bh_selection]
+
+    @lazy_property
+    def BHlasteventa(self):
+        if self.Nbh == 0:
+            return None
+        return np.max(self.agn_eventa)
+
+    @lazy_property
+    def iBHmax(self):
+        if self.Nbh == 0:
+            return None
+        return np.argmax(self.data["PartType5"]["SubgridMasses"][self.bh_selection])
+
+    @lazy_property
+    def BHmaxM(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["SubgridMasses"][self.bh_selection][self.iBHmax]
+
+    @lazy_property
+    def BHmaxID(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["ParticleIDs"][self.bh_selection][self.iBHmax]
+
+    @lazy_property
+    def BHmaxpos(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["Coordinates"][self.bh_selection][self.iBHmax]
+
+    @lazy_property
+    def BHmaxvel(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["Velocities"][self.bh_selection][self.iBHmax]
+
+    @lazy_property
+    def BHmaxAR(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["AccretionRates"][self.bh_selection][self.iBHmax]
+
+    @lazy_property
+    def BHmaxlasteventa(self):
+        if self.Nbh == 0:
+            return None
+        return self.agn_eventa[self.iBHmax]
+
+    @lazy_property
+    def Nnu(self):
+        if "PartType6" in self.data:
+            pos = self.data["PartType6"]["Coordinates"] - self.centre[None, :]
+            nur = np.sqrt(np.sum(pos**2, axis=1))
+            self.nu_selection = nur < self.SO_r
+            return self.nu_selection.sum()
+        else:
+            return unyt.unyt_array(0, dtype=np.uint32, units="dimensionless")
+
+    @lazy_property
+    def Mnu(self):
+        if self.Nnu == 0:
+            return None
+        return self.data["PartType6"]["Masses"][self.nu_selection].sum()
+
+    @lazy_property
+    def MnuNS(self):
+        if self.Nnu == 0:
+            return None
+        return (
+            self.data["PartType6"]["Masses"][self.nu_selection]
+            * self.data["PartType6"]["Weights"][self.nu_selection]
+        ).sum() + self.nu_density * self.SO_volume
+
+
 class SOProperties(HaloProperty):
 
     # Arrays which must be read in for this calculation.
@@ -215,7 +1055,7 @@ class SOProperties(HaloProperty):
             "SubgridMasses",
             "Velocities",
         ],
-        "PartType6": ["Coordinates", "Masses", "Weights"],
+#        "PartType6": ["Coordinates", "Masses", "Weights"],
     }
 
     # get the properties we want from the table
@@ -384,10 +1224,7 @@ class SOProperties(HaloProperty):
         Input particle data arrays are unyt_arrays.
         """
 
-        # Find the halo centre of potential
-        centre = input_halo["cofp"]
-
-        reg = centre.units.registry
+        registry = input_halo["cofp"].units.registry
 
         SO = {}
         # declare all the variables we will compute
@@ -400,468 +1237,73 @@ class SOProperties(HaloProperty):
                 val = [0] * shape
             else:
                 val = 0
-            SO[name] = unyt.unyt_array(val, dtype=dtype, units=unit, registry=reg)
+            SO[name] = unyt.unyt_array(val, dtype=dtype, units=unit, registry=registry)
 
         # SOs only exist for central galaxies
-        if input_halo["Structuretype"] != 10:
-            for name, outputname, _, _, _, description, _, _ in self.property_list:
-                halo_result.update(
-                    {
-                        f"SO/{self.SO_name}/{outputname}": (
-                            SO[name],
-                            description.format(label=self.label),
-                        )
-                    }
+        if input_halo["Structuretype"] == 10:
+
+            types_present = [type for type in self.particle_properties if type in data]
+
+            part_props = SOParticleData(
+                input_halo,
+                data,
+                types_present,
+                self.filter,
+                self.nu_density,
+                self.observer_position,
+            )
+
+            # we need to make sure the physical radius uses the correct unit
+            # registry, since we use it to set the SO radius in some cases
+            physical_radius = unyt.unyt_quantity(
+                self.physical_radius_mpc, units=unyt.Mpc, registry=registry
+            )
+            try:
+                SO_exists = part_props.compute_SO_radius_and_mass(
+                    self.reference_density, physical_radius
                 )
-            return
-
-        # Make an array of particle masses, radii and positions
-        mass = []
-        radius = []
-        position = []
-        velocity = []
-        types = []
-        groupnr = []
-        for ptype in data:
-            if ptype == "PartType6":
-                continue
-            mass.append(data[ptype][mass_dataset(ptype)])
-            pos = data[ptype]["Coordinates"] - centre[None, :]
-            position.append(pos)
-            r = np.sqrt(np.sum(pos**2, axis=1))
-            radius.append(r)
-            velocity.append(data[ptype]["Velocities"])
-            typearr = np.zeros(r.shape, dtype="U9")
-            typearr[:] = ptype
-            types.append(typearr)
-            groupnr.append(data[ptype]["GroupNr_bound"])
-        mass = unyt.array.uconcatenate(mass)
-        radius = unyt.array.uconcatenate(radius)
-        position = unyt.array.uconcatenate(position)
-        velocity = unyt.array.uconcatenate(velocity)
-        types = np.concatenate(types)
-        groupnr = unyt.array.uconcatenate(groupnr)
-
-        # figure out which particles in the list are bound to a halo that is not the
-        # central halo
-        is_bound_to_satellite = (groupnr >= 0) & (groupnr != input_halo["index"])
-
-        # add neutrinos
-        if "PartType6" in data:
-            numass = data["PartType6"]["Masses"] * data["PartType6"]["Weights"]
-            pos = data["PartType6"]["Coordinates"] - centre[None, :]
-            nur = np.sqrt(np.sum(pos**2, axis=1))
-            all_mass = unyt.array.uconcatenate([mass, numass])
-            all_r = unyt.array.uconcatenate([radius, nur])
-        else:
-            all_mass = mass
-            all_r = radius
-
-        # Sort by radius
-        order = np.argsort(all_r)
-        ordered_radius = all_r[order]
-        cumulative_mass = np.cumsum(all_mass[order], dtype=np.float64).astype(
-            mass.dtype
-        )
-        # add mean neutrino mass
-        cumulative_mass += self.nu_density * 4.0 / 3.0 * np.pi * ordered_radius**3
-
-        # Compute density within radius of each particle.
-        # Will need to skip any at zero radius.
-        # Note that because of the definition of the centre of potential, the first
-        # particle *should* be at r=0. We need to manually exclude it, in case round
-        # off error places it at a very small non-zero radius.
-        nskip = max(1, np.argmax(ordered_radius > 0.0 * ordered_radius.units))
-        ordered_radius = ordered_radius[nskip:]
-        cumulative_mass = cumulative_mass[nskip:]
-        nr_parts = len(ordered_radius)
-        density = cumulative_mass / (4.0 / 3.0 * np.pi * ordered_radius**3)
-
-        # Check if we ever reach the density threshold
-        if self.reference_density > 0.0 * self.reference_density:
-            if nr_parts > 0:
-                try:
-                    SO_r, SO_mass, SO_volume = find_SO_radius_and_mass(
-                        ordered_radius,
-                        density,
-                        cumulative_mass,
-                        self.reference_density,
-                    )
-                    SO["r"] += SO_r
-                    SO["Mtot"] += SO_mass
-                except ReadRadiusTooSmallError:
-                    raise ReadRadiusTooSmallError("SO radius multiple was too small!")
-            else:
-                SO_volume = 4.0 * np.pi / 3.0 * SO["r"] ** 3
-        elif self.physical_radius_mpc > 0.0:
-            SO["r"] += self.physical_radius_mpc * unyt.Mpc
-            SO_volume = 4.0 * np.pi / 3.0 * SO["r"] ** 3
-            if nr_parts > 0:
-                # find the enclosed mass using interpolation
-                outside_radius = ordered_radius > SO["r"]
-                if not np.any(outside_radius):
-                    # all particles are within the radius, we cannot interpolate
-                    SO["Mtot"] += cumulative_mass[-1]
-                else:
-                    i = np.argmax(outside_radius)
-                    if i == 0:
-                        # we only have particles in the centre, so we cannot interpolate
-                        SO["Mtot"] += cumulative_mass[i]
-                    else:
-                        r1 = ordered_radius[i - 1]
-                        r2 = ordered_radius[i]
-                        M1 = cumulative_mass[i - 1]
-                        M2 = cumulative_mass[i]
-                        SO["Mtot"] += M1 + (SO["r"] - r1) / (r2 - r1) * (M2 - M1)
-
-        else:
-            # if we get here, we must be in the case where physical_radius_mpc is supposed to be 0
-            # that can only happen if we are looking at a multiple of some radius
-            # in that case, SO["r"] should remain 0
-            # in any other case, something went wrong
-            if not hasattr(self, "multiple"):
-                raise RuntimeError(
-                    "Physical radius was set to 0! This should not happen!"
+            except ReadRadiusTooSmallError:
+                raise ReadRadiusTooSmallError(
+                    f"Need more particles to determine SO radius and mass!"
                 )
 
-        # the second condition is necessary to deal with physical SO radii and
-        # no particles
-        if SO["r"] > 0.0 * radius.units and SO["Mtot"] > 0.0 * mass.units:
+            if SO_exists:
 
-            gas_selection = radius[types == "PartType0"] < SO["r"]
-            dm_selection = radius[types == "PartType1"] < SO["r"]
-            star_selection = radius[types == "PartType4"] < SO["r"]
-            bh_selection = radius[types == "PartType5"] < SO["r"]
+                Ngas = halo_result[
+                    f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}"
+                ][0].value
+                Ndm = halo_result[
+                    f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}"
+                ][0].value
+                Nstar = halo_result[
+                    f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}"
+                ][0].value
+                Nbh = halo_result[
+                    f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}"
+                ][0].value
 
-            all_selection = radius < SO["r"]
-            mass = mass[all_selection]
-            radius = radius[all_selection]
-            position = position[all_selection]
-            velocity = velocity[all_selection]
-            types = types[all_selection]
-            is_bound_to_satellite = is_bound_to_satellite[all_selection]
+                do_calculation = {
+                    "basic": True,
+                    "general": Ngas + Ndm + Nstar + Nbh > 100,
+                    "gas": Ngas > 50,
+                    "dm": Ndm > 100,
+                    "star": Nstar > 50,
+                    "baryon": Ngas + Nstar > 100,
+                }
 
-            # note that we cannot divide by mSO here, since that was based on an interpolation
-            Mtotpart = mass.sum()
-            mass_frac = mass / Mtotpart
-            SO["com"] += (mass_frac[:, None] * position).sum(axis=0)
-            SO["com"] += centre
-            SO["vcom"] += (mass_frac[:, None] * velocity).sum(axis=0)
-            if Mtotpart > 0.0 * Mtotpart.units:
-                _, vmax = get_vmax(mass, radius)
-                if vmax > 0.0 * vmax.units:
-                    vrel = velocity - SO["vcom"][None, :]
-                    Ltot = unyt.array.unorm(
-                        (mass[:, None] * unyt.array.ucross(position, vrel)).sum(axis=0)
-                    )
-                    SO["spin_parameter"] += Ltot / (
-                        np.sqrt(2.0) * Mtotpart * SO["r"] * vmax
-                    )
-                SO["TotalAxisLengths"] += get_axis_lengths(mass, position)
-
-            SO["Mfrac_satellites"] += mass[is_bound_to_satellite].sum() / SO["Mtot"]
-
-            gas_masses = mass[types == "PartType0"]
-            gas_pos = position[types == "PartType0"]
-            gas_vel = velocity[types == "PartType0"]
-            SO["Mgas"] += gas_masses.sum()
-            if SO["Mgas"] > 0.0 * SO["Mgas"].units:
-                frac_mgas = gas_masses / SO["Mgas"]
-                SO["com_gas"] += (frac_mgas[:, None] * gas_pos).sum(axis=0)
-                SO["com_gas"] += centre
-                SO["vcom_gas"] += (frac_mgas[:, None] * gas_vel).sum(axis=0)
-
-                Lgas, _, Mcountrot = get_angular_momentum_and_kappa_corot(
-                    gas_masses,
-                    gas_pos,
-                    gas_vel,
-                    ref_velocity=SO["vcom_gas"],
-                    do_counterrot_mass=True,
-                )
-                SO["Lgas"] += Lgas
-                SO["DtoTgas"] += 1.0 - 2.0 * Mcountrot / SO["Mgas"]
-                """
-                SO["veldisp_matrix_gas"] += get_velocity_dispersion_matrix(
-                    frac_mgas, gas_vel, SO["vcom_gas"]
-                )
-                """
-                SO["GasAxisLengths"] += get_axis_lengths(gas_masses, gas_pos)
-
-            dm_masses = mass[types == "PartType1"]
-            dm_pos = position[types == "PartType1"]
-            dm_vel = velocity[types == "PartType1"]
-            SO["Mdm"] += dm_masses.sum()
-            if SO["Mdm"] > 0.0 * SO["Mdm"].units:
-                frac_mdm = dm_masses / SO["Mdm"]
-                vcom_dm = (frac_mdm[:, None] * dm_vel).sum(axis=0)
-
-                SO["Ldm"] += get_angular_momentum(
-                    dm_masses, dm_pos, dm_vel, ref_velocity=vcom_dm
-                )
-                """
-                SO["veldisp_matrix_dm"] += get_velocity_dispersion_matrix(
-                    frac_mdm, dm_vel, vcom_dm
-                )
-                """
-                SO["DMAxisLengths"] += get_axis_lengths(dm_masses, dm_pos)
-
-            star_masses = mass[types == "PartType4"]
-            star_pos = position[types == "PartType4"]
-            star_vel = velocity[types == "PartType4"]
-            SO["Mstar"] += star_masses.sum()
-            if SO["Mstar"] > 0.0 * SO["Mstar"].units:
-                frac_mstar = star_masses / SO["Mstar"]
-                SO["com_star"] += (frac_mstar[:, None] * star_pos).sum(axis=0)
-                SO["com_star"] += centre
-                SO["vcom_star"] += (frac_mstar[:, None] * star_vel).sum(axis=0)
-
-                Lstar, _, Mcountrot = get_angular_momentum_and_kappa_corot(
-                    star_masses,
-                    star_pos,
-                    star_vel,
-                    ref_velocity=SO["vcom_star"],
-                    do_counterrot_mass=True,
-                )
-                SO["Lstar"] += Lstar
-                SO["DtoTstar"] += 1.0 - 2.0 * Mcountrot / SO["Mstar"]
-                """
-                SO["veldisp_matrix_star"] += get_velocity_dispersion_matrix(
-                    frac_mstar, star_vel, SO["vcom_star"]
-                )
-                """
-                SO["StellarAxisLengths"] += get_axis_lengths(star_masses, star_pos)
-
-            baryon_masses = mass[(types == "PartType0") | (types == "PartType4")]
-            baryon_pos = position[(types == "PartType0") | (types == "PartType4")]
-            baryon_vel = velocity[(types == "PartType0") | (types == "PartType4")]
-            Mbaryons = baryon_masses.sum()
-            if Mbaryons > 0.0 * Mbaryons.units:
-                baryon_vcom = ((baryon_masses / Mbaryons)[:, None] * baryon_vel).sum(
-                    axis=0
-                )
-                baryon_relvel = baryon_vel - baryon_vcom[None, :]
-                SO["Lbaryons"] += (
-                    baryon_masses[:, None]
-                    * unyt.array.ucross(baryon_pos, baryon_relvel)
-                ).sum(axis=0)
-                SO["BaryonAxisLengths"] += get_axis_lengths(baryon_masses, baryon_pos)
-
-            SO["Mbh_dynamical"] += mass[types == "PartType5"].sum()
-
-            # gas specific properties. We (can) only do these if we have gas.
-            # (remember that "PartType0" might not be part of 'data' at all)
-            if np.any(gas_selection):
-                SO["Ngas"] = (
-                    gas_selection.sum(dtype=SO["Ngas"].dtype) * SO["Ngas"].units
-                )
-
-                SO["Mgasmetal"] += (
-                    gas_masses * data["PartType0"]["MetalMassFractions"][gas_selection]
-                ).sum()
-
-                SO["MgasO"] += (
-                    gas_masses
-                    * data["PartType0"]["SmoothedElementMassFractions"][gas_selection][
-                        :, indexO
-                    ]
-                ).sum()
-                SO["MgasFe"] += (
-                    gas_masses
-                    * data["PartType0"]["SmoothedElementMassFractions"][gas_selection][
-                        :, indexFe
-                    ]
-                ).sum()
-
-                gas_temperatures = data["PartType0"]["Temperatures"][gas_selection]
-                SO["Tgas"] += (gas_temperatures * (gas_masses / SO["Mgas"])).sum()
-                Tgas_selection = gas_temperatures > 1.0e5 * unyt.K
-                SO["Mhotgas"] += gas_masses[Tgas_selection].sum()
-
-                if np.any(Tgas_selection):
-                    SO["Tgas_no_cool"] += (
-                        gas_temperatures[Tgas_selection] * gas_masses[Tgas_selection]
-                    ).sum() / SO["Mhotgas"]
-
-                SFR = data["PartType0"]["StarFormationRates"][gas_selection]
-                is_SFR = SFR > 0.0
-                SO["SFR"] += SFR[is_SFR].sum()
-
-                xraylum = data["PartType0"]["XrayLuminosities"][gas_selection]
-                xrayphlum = data["PartType0"]["XrayPhotonLuminosities"][gas_selection]
-                SO["Xraylum"] += xraylum.sum()
-                SO["Xrayphlum"] += xrayphlum.sum()
-
-                compY = data["PartType0"]["ComptonYParameters"][gas_selection]
-                # unyt has some internal issue that causes an overflow when
-                # converting from compY.units to SO["compY"].units.
-                # we avoid this issue by manually converting the unit
-                unit = 1.0 * compY.units
-                new_unit = unit.to(SO["compY"].units)
-                SO["compY"] += compY.sum().value * new_unit
-
-                last_agn_gas = data["PartType0"]["LastAGNFeedbackScaleFactors"][
-                    gas_selection
-                ]
-                no_agn = ~self.filter.is_recently_heated(last_agn_gas, gas_temperatures)
-                if np.any(no_agn):
-                    SO["Xraylum_no_agn"] += xraylum[no_agn].sum()
-                    SO["Xrayphlum_no_agn"] += xrayphlum[no_agn].sum()
-                    SO["compY_no_agn"] += compY[no_agn].sum().value * new_unit
-                    mass_gas_no_agn = gas_masses[no_agn]
-                    Mgas_no_agn = mass_gas_no_agn.sum()
-                    if Mgas_no_agn > 0.0:
-                        SO["Tgas_no_agn"] += (
-                            (mass_gas_no_agn / Mgas_no_agn) * gas_temperatures[no_agn]
-                        ).sum()
-
-                no_cool_no_agn = Tgas_selection & no_agn
-                if np.any(no_cool_no_agn):
-                    mass_gas_no_cool_no_agn = gas_masses[no_cool_no_agn]
-                    Mgas_no_cool_no_agn = mass_gas_no_cool_no_agn.sum()
-                    if Mgas_no_cool_no_agn > 0.0:
-                        SO["Tgas_no_cool_no_agn"] += (
-                            (mass_gas_no_cool_no_agn / Mgas_no_cool_no_agn)
-                            * gas_temperatures[no_cool_no_agn]
-                        ).sum()
-
-                # below we need to force conversion to np.float64 before summing up particles
-                # to avoid overflow
-                vgas = velocity[types == "PartType0"]
-                ekin_gas = gas_masses * ((vgas - SO["vcom_gas"][None, :]) ** 2).sum(
-                    axis=1
-                )
-                ekin_gas = unyt.unyt_array(
-                    ekin_gas.value, dtype=np.float64, units=ekin_gas.units
-                )
-                SO["Ekin_gas"] += 0.5 * ekin_gas.sum()
-                gas_densities = data["PartType0"]["Densities"][gas_selection]
-                etherm_gas = (
-                    1.5
-                    * gas_masses
-                    * data["PartType0"]["Pressures"][gas_selection]
-                    / gas_densities
-                )
-                etherm_gas = unyt.unyt_array(
-                    etherm_gas.value, dtype=np.float64, units=etherm_gas.units
-                )
-                SO["Etherm_gas"] += etherm_gas.sum()
-
-                ne = data["PartType0"]["ElectronNumberDensities"][gas_selection]
-                # note: the positions where relative to the centre, so we have
-                # to make them absolute again before subtracting the observer
-                # position
-                relpos = (
-                    position[types == "PartType0"]
-                    + centre[None, :]
-                    - self.observer_position[None, :]
-                )
-                distance = np.sqrt((relpos**2).sum(axis=1))
-                # we need to exclude particles at zero distance
-                # (we assume those have no relative velocity)
-                vr = unyt.unyt_array(
-                    np.zeros(vgas.shape[0]), dtype=vgas.dtype, units=vgas.units
-                )
-                has_distance = distance > 0.0
-                vr[has_distance] = (
-                    vgas[has_distance, 0] * relpos[has_distance, 0]
-                    + vgas[has_distance, 1] * relpos[has_distance, 1]
-                    + vgas[has_distance, 2] * relpos[has_distance, 2]
-                ) / distance[has_distance]
-                fac = unyt.sigma_thompson / unyt.c
-                volumes = gas_masses / gas_densities
-                area = np.pi * SO["r"] ** 2
-                SO["DopplerB"] += (fac * ne * vr * (volumes / area)).sum()
-
-            if np.any(dm_selection):
-                SO["Ndm"] = dm_selection.sum(dtype=SO["Ndm"].dtype) * SO["Ndm"].units
-
-            # star specific properties
-            if np.any(star_selection):
-                SO["Nstar"] = (
-                    star_selection.sum(dtype=SO["Nstar"].dtype) * SO["Nstar"].units
-                )
-
-                SO["Mstar_init"] += data["PartType4"]["InitialMasses"][
-                    star_selection
-                ].sum()
-                SO["Mstarmetal"] += (
-                    star_masses
-                    * data["PartType4"]["MetalMassFractions"][star_selection]
-                ).sum()
-
-                SO["MstarO"] += (
-                    star_masses
-                    * data["PartType4"]["SmoothedElementMassFractions"][star_selection][
-                        :, indexO
-                    ]
-                ).sum()
-                SO["MstarFe"] += (
-                    star_masses
-                    * data["PartType4"]["SmoothedElementMassFractions"][star_selection][
-                        :, indexFe
-                    ]
-                ).sum()
-
-                SO["StellarLuminosity"] += data["PartType4"]["Luminosities"][
-                    star_selection
-                ].sum()
-
-                # below we need to force conversion to np.float64 before summing up particles
-                # to avoid overflow
-                ekin_star = star_masses * (
-                    (velocity[types == "PartType4"] - SO["vcom_star"][None, :]) ** 2
-                ).sum(axis=1)
-                ekin_star = unyt.unyt_array(
-                    ekin_star.value, dtype=np.float64, units=ekin_star.units
-                )
-                SO["Ekin_star"] += 0.5 * ekin_star.sum()
-
-            # BH specific properties
-            if np.any(bh_selection):
-                SO["Nbh"] = bh_selection.sum(dtype=SO["Nbh"].dtype) * SO["Nbh"].units
-
-                SO["Mbh_subgrid"] += data["PartType5"]["SubgridMasses"][
-                    bh_selection
-                ].sum()
-                agn_eventa = data["PartType5"]["LastAGNFeedbackScaleFactors"][
-                    bh_selection
-                ]
-
-                SO["BHlasteventa"] += np.max(agn_eventa)
-
-                iBHmax = np.argmax(data["PartType5"]["SubgridMasses"][bh_selection])
-                SO["BHmaxM"] += data["PartType5"]["SubgridMasses"][bh_selection][iBHmax]
-                # unyt annoyingly converts to a floating point type if you use '+='
-                # the only way to avoid this is by directly setting the data for the unyt_array
-                # however, that is unsafe and results in a warning
-                # the only option left is to replace the array with a new copy
-                SO["BHmaxID"] = unyt.unyt_array(
-                    data["PartType5"]["ParticleIDs"][bh_selection][iBHmax].value,
-                    dtype=SO["BHmaxID"].dtype,
-                    units=SO["BHmaxID"].units,
-                )
-                SO["BHmaxpos"] += data["PartType5"]["Coordinates"][bh_selection][iBHmax]
-                SO["BHmaxvel"] += data["PartType5"]["Velocities"][bh_selection][iBHmax]
-                SO["BHmaxAR"] += data["PartType5"]["AccretionRates"][bh_selection][
-                    iBHmax
-                ]
-                SO["BHmaxlasteventa"] += agn_eventa[iBHmax]
-
-            # Neutrino specific properties
-            if "PartType6" in data:
-                pos = data["PartType6"]["Coordinates"] - centre[None, :]
-                nur = np.sqrt(np.sum(pos**2, axis=1))
-                nu_selection = nur < SO["r"]
-                SO["Mnu"] += data["PartType6"]["Masses"][nu_selection].sum()
-                SO["MnuNS"] += (
-                    data["PartType6"]["Masses"][nu_selection]
-                    * data["PartType6"]["Weights"][nu_selection]
-                ).sum()
-                SO["MnuNS"] += self.nu_density * SO_volume
-                if np.any(nu_selection):
-                    SO["Nnu"] = (
-                        nu_selection.sum(dtype=SO["Nnu"].dtype) * SO["Nnu"].units
-                    )
+                for name, _, shape, dtype, unit, _, category, _ in self.property_list:
+                    if do_calculation[category]:
+                        val = getattr(part_props, name)
+                        if val is not None:
+                            if unit == "dimensionless":
+                                SO[name] = unyt.unyt_array(
+                                    val.astype(dtype),
+                                    dtype=dtype,
+                                    units=unit,
+                                    registry=registry,
+                                )
+                            else:
+                                SO[name] += val
 
         # Return value should be a dict containing unyt_arrays and descriptions.
         # The dict keys will be used as HDF5 dataset names in the output.
@@ -947,9 +1389,48 @@ def test_SO_properties():
     )
 
     for i in range(100):
-        input_halo, data, rmax, Mtot, Npart, _ = dummy_halos.get_random_halo(
-            [2, 10, 100, 1000, 10000], has_neutrinos=True
-        )
+        (
+            input_halo,
+            data,
+            rmax,
+            Mtot,
+            Npart,
+            particle_numbers,
+        ) = dummy_halos.get_random_halo([2, 10, 100, 1000, 10000], has_neutrinos=True)
+        halo_result_template = {
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType0"],
+                    dtype=PropertyTable.full_property_list["Ngas"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Ngas for filter",
+            ),
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType1"],
+                    dtype=PropertyTable.full_property_list["Ndm"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Ndm for filter",
+            ),
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType4"],
+                    dtype=PropertyTable.full_property_list["Nstar"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Nstar for filter",
+            ),
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType5"],
+                    dtype=PropertyTable.full_property_list["Nbh"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Nbh for filter",
+            ),
+        }
         rho_ref = Mtot / (4.0 / 3.0 * np.pi * rmax**3)
 
         # force the SO radius to be outside the search sphere and check that
@@ -964,7 +1445,7 @@ def test_SO_properties():
         ]:
             fail = False
             try:
-                halo_result = {}
+                halo_result = dict(halo_result_template)
                 prop_calc.calculate(input_halo, rmax, data, halo_result)
             except ReadRadiusTooSmallError:
                 fail = True
@@ -979,7 +1460,7 @@ def test_SO_properties():
         # required radius
         fail = False
         try:
-            halo_result = {}
+            halo_result = dict(halo_result_template)
             property_calculator_5x2500mean.calculate(
                 input_halo, rmax, data, halo_result
             )
@@ -990,12 +1471,15 @@ def test_SO_properties():
         # force the radius multiple to trip over the search radius
         fail = False
         try:
-            halo_result = {
-                f"SO/2500_mean/{property_calculator_5x2500mean.radius_name}": (
-                    0.1 * rmax,
-                    "Dummy value.",
-                )
-            }
+            halo_result = dict(halo_result_template)
+            halo_result.update(
+                {
+                    f"SO/2500_mean/{property_calculator_5x2500mean.radius_name}": (
+                        0.1 * rmax,
+                        "Dummy value.",
+                    )
+                }
+            )
             property_calculator_5x2500mean.calculate(
                 input_halo, 0.2 * rmax, data, halo_result
             )
@@ -1016,7 +1500,7 @@ def test_SO_properties():
             ("5xR_2500_mean", property_calculator_5x2500mean),
         ]:
 
-            halo_result = {}
+            halo_result = dict(halo_result_template)
             # make sure the radius multiple is found this time
             if SO_name == "5xR_2500_mean":
                 halo_result[

--- a/SO_properties.py
+++ b/SO_properties.py
@@ -395,7 +395,7 @@ class SOProperties(HaloProperty):
         # all variables are defined with physical units and an appropriate dtype
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
-        for name, _, shape, dtype, unit, _, _ in self.property_list:
+        for name, _, shape, dtype, unit, _, _, _ in self.property_list:
             if shape > 1:
                 val = [0] * shape
             else:
@@ -404,7 +404,7 @@ class SOProperties(HaloProperty):
 
         # SOs only exist for central galaxies
         if input_halo["Structuretype"] != 10:
-            for name, outputname, _, _, _, description, _ in self.property_list:
+            for name, outputname, _, _, _, description, _, _ in self.property_list:
                 halo_result.update(
                     {
                         f"SO/{self.SO_name}/{outputname}": (
@@ -865,7 +865,7 @@ class SOProperties(HaloProperty):
 
         # Return value should be a dict containing unyt_arrays and descriptions.
         # The dict keys will be used as HDF5 dataset names in the output.
-        for name, outputname, _, _, _, description, _ in self.property_list:
+        for name, outputname, _, _, _, description, _, _ in self.property_list:
             halo_result.update(
                 {
                     f"SO/{self.SO_name}/{outputname}": (
@@ -1044,6 +1044,7 @@ def test_SO_properties():
                 size,
                 dtype,
                 unit_string,
+                _,
                 _,
                 _,
             ) in prop_calc.property_list:

--- a/SO_properties.py
+++ b/SO_properties.py
@@ -1213,6 +1213,8 @@ class SOProperties(HaloProperty):
 
         registry = input_halo["cofp"].units.registry
 
+        do_calculation = self.category_filter.get_filters(halo_result)
+
         SO = {}
         # declare all the variables we will compute
         # we set them to 0 in case a particular variable cannot be computed
@@ -1220,6 +1222,10 @@ class SOProperties(HaloProperty):
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
         for prop in self.property_list:
+            # skip non-DMO properties in DMO run mode
+            is_dmo = prop[8]
+            if do_calculation["DMO"] and not is_dmo:
+                continue
             name = prop[0]
             shape = prop[2]
             dtype = prop[3]
@@ -1260,9 +1266,11 @@ class SOProperties(HaloProperty):
 
             if SO_exists:
 
-                do_calculation = self.category_filter.get_filters(halo_result)
-
                 for prop in self.property_list:
+                    # skip non-DMO properties in DMO run mode
+                    is_dmo = prop[8]
+                    if do_calculation["DMO"] and not is_dmo:
+                        continue
                     name = prop[0]
                     dtype = prop[3]
                     unit = prop[4]
@@ -1283,6 +1291,10 @@ class SOProperties(HaloProperty):
         # Return value should be a dict containing unyt_arrays and descriptions.
         # The dict keys will be used as HDF5 dataset names in the output.
         for prop in self.property_list:
+            # skip non-DMO properties in DMO run mode
+            is_dmo = prop[8]
+            if do_calculation["DMO"] and not is_dmo:
+                continue
             name = prop[0]
             outputname = prop[1]
             description = prop[5]

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -972,7 +972,12 @@ class ApertureProperties(HaloProperty):
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
         registry = part_props.mass.units.registry
-        for name, _, shape, dtype, unit, _, category, _ in self.property_list:
+        for prop in self.property_list:
+            name = prop[0]
+            shape = prop[2]
+            dtype = prop[3]
+            unit = prop[4]
+            category = prop[6]
             if shape > 1:
                 val = [0] * shape
             else:
@@ -997,7 +1002,10 @@ class ApertureProperties(HaloProperty):
             prefix = f"InclusiveSphere/{self.physical_radius_mpc*1000.:.0f}kpc"
         else:
             prefix = f"ExclusiveSphere/{self.physical_radius_mpc*1000.:.0f}kpc"
-        for name, outputname, _, _, _, description, _, _ in self.property_list:
+        for prop in self.property_list:
+            name = prop[0]
+            outputname = prop[1]
+            description = prop[5]
             halo_result.update(
                 {
                     f"{prefix}/{outputname}": (
@@ -1135,16 +1143,11 @@ def test_aperture_properties():
             assert input_data == input_data_copy
 
             # check that the calculation returns the correct values
-            for (
-                _,
-                outputname,
-                size,
-                dtype,
-                unit_string,
-                _,
-                _,
-                _,
-            ) in pc_calc.property_list:
+            for prop in pc_calc.property_list:
+                outputname = prop[1]
+                size = prop[2]
+                dtype = prop[3]
+                unit_string = prop[4]
                 full_name = f"{pc_type}/50kpc/{outputname}"
                 assert full_name in halo_result
                 result = halo_result[full_name][0]

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -211,7 +211,7 @@ class ApertureProperties(HaloProperty):
         # all variables are defined with physical units and an appropriate dtype
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
-        for name, _, shape, dtype, unit, _, _ in self.property_list:
+        for name, _, shape, dtype, unit, _, _, _ in self.property_list:
             if shape > 1:
                 val = [0] * shape
             else:
@@ -546,7 +546,7 @@ class ApertureProperties(HaloProperty):
             prefix = f"InclusiveSphere/{self.physical_radius_mpc*1000.:.0f}kpc"
         else:
             prefix = f"ExclusiveSphere/{self.physical_radius_mpc*1000.:.0f}kpc"
-        for name, outputname, _, _, _, description, _ in self.property_list:
+        for name, outputname, _, _, _, description, _, _ in self.property_list:
             halo_result.update(
                 {
                     f"{prefix}/{outputname}": (
@@ -622,6 +622,7 @@ def test_aperture_properties():
                 size,
                 dtype,
                 unit_string,
+                _,
                 _,
                 _,
             ) in pc_calc.property_list:

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -16,12 +16,783 @@ from kinematic_properties import (
 from recently_heated_gas_filter import RecentlyHeatedGasFilter
 from stellar_age_calculator import StellarAgeCalculator
 from property_table import PropertyTable
+from lazy_properties import lazy_property
 
 # index of elements O and Fe in the SmoothedElementMassFractions dataset
 indexO = 4
 indexFe = 8
 
 rbandindex = 2
+
+
+def set_halo_property(prop_dict, name, part_props):
+    prop_info = PropertyTable.full_property_list[name]
+    dtype = prop_info[2]
+    units = prop_info[3]
+    val = getattr(part_props, name)
+    if val is not None:
+        if units == "dimensionless":
+            prop_dict[name] = unyt.unyt_array(
+                val.astype(dtype), dtype=dtype, units=units
+            )
+        else:
+            prop_dict[name] += val
+
+
+class ApertureParticleData:
+    def __init__(
+        self,
+        input_halo,
+        data,
+        types_present,
+        inclusive,
+        aperture_radius,
+        stellar_age_calculator,
+        recently_heated_gas_filter,
+    ):
+        self.input_halo = input_halo
+        self.data = data
+        self.types_present = types_present
+        self.inclusive = inclusive
+        self.aperture_radius = aperture_radius
+        self.stellar_age_calculator = stellar_age_calculator
+        self.recently_heated_gas_filter = recently_heated_gas_filter
+        self.compute_basics()
+
+    def compute_basics(self):
+        self.centre = self.input_halo["cofp"]
+        self.index = self.input_halo["index"]
+        mass = []
+        position = []
+        radius = []
+        velocity = []
+        types = []
+        for ptype in self.types_present:
+            grnr = self.data[ptype]["GroupNr_bound"]
+            if self.inclusive:
+                in_halo = np.ones(grnr.shape, dtype=bool)
+            else:
+                in_halo = grnr == self.index
+            mass.append(self.data[ptype][mass_dataset(ptype)][in_halo])
+            pos = self.data[ptype]["Coordinates"][in_halo, :] - self.centre[None, :]
+            position.append(pos)
+            r = np.sqrt(pos[:, 0] ** 2 + pos[:, 1] ** 2 + pos[:, 2] ** 2)
+            radius.append(r)
+            velocity.append(self.data[ptype]["Velocities"][in_halo, :])
+            typearr = np.zeros(r.shape, dtype="U9")
+            typearr[:] = ptype
+            types.append(typearr)
+
+        self.mass = unyt.array.uconcatenate(mass)
+        self.position = unyt.array.uconcatenate(position)
+        self.radius = unyt.array.uconcatenate(radius)
+        self.velocity = unyt.array.uconcatenate(velocity)
+        self.types = np.concatenate(types)
+
+        self.mask = self.radius <= self.aperture_radius
+
+        self.mass = self.mass[self.mask]
+        self.position = self.position[self.mask]
+        self.velocity = self.velocity[self.mask]
+        self.radius = self.radius[self.mask]
+        self.type = self.types[self.mask]
+
+    @lazy_property
+    def gas_mask_ap(self):
+        return self.mask[self.types == "PartType0"]
+
+    @lazy_property
+    def dm_mask_ap(self):
+        return self.mask[self.types == "PartType1"]
+
+    @lazy_property
+    def star_mask_ap(self):
+        return self.mask[self.types == "PartType4"]
+
+    @lazy_property
+    def bh_mask_ap(self):
+        return self.mask[self.types == "PartType5"]
+
+    @lazy_property
+    def baryon_mask_ap(self):
+        return self.mask[(self.types == "PartType0") | (self.types == "PartType4")]
+
+    @lazy_property
+    def Ngas(self):
+        return self.gas_mask_ap.sum()
+
+    @lazy_property
+    def Ndm(self):
+        return self.dm_mask_ap.sum()
+
+    @lazy_property
+    def Nstar(self):
+        return self.star_mask_ap.sum()
+
+    @lazy_property
+    def Nbh(self):
+        return self.bh_mask_ap.sum()
+
+    @lazy_property
+    def Nbaryon(self):
+        return self.baryon_mask_ap.sum()
+
+    @lazy_property
+    def mass_gas(self):
+        return self.mass[self.type == "PartType0"]
+
+    @lazy_property
+    def mass_dm(self):
+        return self.mass[self.type == "PartType1"]
+
+    @lazy_property
+    def mass_star(self):
+        return self.mass[self.type == "PartType4"]
+
+    @lazy_property
+    def mass_baryons(self):
+        return self.mass[(self.type == "PartType0") | (self.type == "PartType4")]
+
+    @lazy_property
+    def pos_gas(self):
+        return self.position[self.type == "PartType0"]
+
+    @lazy_property
+    def pos_dm(self):
+        return self.position[self.type == "PartType1"]
+
+    @lazy_property
+    def pos_star(self):
+        return self.position[self.type == "PartType4"]
+
+    @lazy_property
+    def pos_baryons(self):
+        return self.position[(self.type == "PartType0") | (self.type == "PartType4")]
+
+    @lazy_property
+    def vel_gas(self):
+        return self.velocity[self.type == "PartType0"]
+
+    @lazy_property
+    def vel_dm(self):
+        return self.velocity[self.type == "PartType1"]
+
+    @lazy_property
+    def vel_star(self):
+        return self.velocity[self.type == "PartType4"]
+
+    @lazy_property
+    def vel_baryons(self):
+        return self.velocity[(self.type == "PartType0") | (self.type == "PartType4")]
+
+    @lazy_property
+    def Mtot(self):
+        return self.mass.sum()
+
+    @lazy_property
+    def Mgas(self):
+        return self.mass_gas.sum()
+
+    @lazy_property
+    def Mdm(self):
+        return self.mass_dm.sum()
+
+    @lazy_property
+    def Mstar(self):
+        return self.mass_star.sum()
+
+    @lazy_property
+    def Mbh_dynamical(self):
+        return self.mass[self.type == "PartType5"].sum()
+
+    @lazy_property
+    def Mbaryons(self):
+        return self.Mgas + self.Mstar
+
+    @lazy_property
+    def star_mask_all(self):
+        if self.Nstar == 0:
+            return None
+        if self.inclusive:
+            return np.ones(self.data["PartType4"]["GroupNr_bound"].shape, dtype=bool)
+        else:
+            return self.data["PartType4"]["GroupNr_bound"] == self.index
+
+    @lazy_property
+    def Mstar_init(self):
+        if self.Nstar == 0:
+            return None
+        return self.data["PartType4"]["InitialMasses"][self.star_mask_all][
+            self.star_mask_ap
+        ].sum()
+
+    @lazy_property
+    def stellar_luminosities(self):
+        if self.Nstar == 0:
+            return None
+        return self.data["PartType4"]["Luminosities"][self.star_mask_all][
+            self.star_mask_ap
+        ]
+
+    @lazy_property
+    def StellarLuminosity(self):
+        if self.Nstar == 0:
+            return None
+        return self.stellar_luminosities.sum(axis=0)
+
+    @lazy_property
+    def Mstarmetal(self):
+        if self.Nstar == 0:
+            return None
+        return (
+            self.mass_star
+            * self.data["PartType4"]["MetalMassFractions"][self.star_mask_all][
+                self.star_mask_ap
+            ]
+        ).sum()
+
+    @lazy_property
+    def stellar_MstarO(self):
+        if self.Nstar == 0:
+            return None
+        return (
+            self.mass_star
+            * self.data["PartType4"]["SmoothedElementMassFractions"][
+                self.star_mask_all
+            ][self.star_mask_ap][:, indexO]
+        )
+
+    @lazy_property
+    def MstarO(self):
+        if self.Nstar == 0:
+            return None
+        return self.stellar_MstarO.sum()
+
+    @lazy_property
+    def stellar_MstarFe(self):
+        if self.Nstar == 0:
+            return None
+        return (
+            self.mass_star
+            * self.data["PartType4"]["SmoothedElementMassFractions"][
+                self.star_mask_all
+            ][self.star_mask_ap][:, indexFe]
+        )
+
+    @lazy_property
+    def MstarFe(self):
+        if self.Nstar == 0:
+            return None
+        return self.stellar_MstarFe.sum()
+
+    @lazy_property
+    def stellar_ages(self):
+        if self.Nstar == 0:
+            return None
+        birth_a = self.data["PartType4"]["BirthScaleFactors"][self.star_mask_all][
+            self.star_mask_ap
+        ]
+        return self.stellar_age_calculator.stellar_age(birth_a)
+
+    @lazy_property
+    def star_mass_fraction(self):
+        if self.Mstar == 0:
+            return None
+        return self.mass_star / self.Mstar
+
+    @lazy_property
+    def stellar_age_mw(self):
+        if self.Nstar == 0 or self.Mstar == 0:
+            return None
+        return (self.star_mass_fraction * self.stellar_ages).sum()
+
+    @lazy_property
+    def stellar_age_lw(self):
+        if self.Nstar == 0:
+            return None
+        Lr = self.stellar_luminosities[:, rbandindex]
+        Lrtot = Lr.sum()
+        if Lrtot == 0:
+            return None
+        return ((Lr / Lrtot) * self.stellar_ages).sum()
+
+    @lazy_property
+    def bh_mask_all(self):
+        if self.Nbh == 0:
+            return None
+        if self.inclusive:
+            return np.ones(self.data["PartType5"]["GroupNr_bound"].shape, dtype=bool)
+        else:
+            return self.data["PartType5"]["GroupNr_bound"] == self.index
+
+    @lazy_property
+    def Mbh_subgrid(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["SubgridMasses"][self.bh_mask_all][
+            self.bh_mask_ap
+        ].sum()
+
+    @lazy_property
+    def agn_eventa(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["LastAGNFeedbackScaleFactors"][self.bh_mask_all][
+            self.bh_mask_ap
+        ]
+
+    @lazy_property
+    def BHlasteventa(self):
+        if self.Nbh == 0:
+            return None
+        return np.max(self.agn_eventa)
+
+    @lazy_property
+    def iBHmax(self):
+        if self.Nbh == 0:
+            return None
+        return np.argmax(
+            self.data["PartType5"]["SubgridMasses"][self.bh_mask_all][self.bh_mask_ap]
+        )
+
+    @lazy_property
+    def BHmaxM(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["SubgridMasses"][self.bh_mask_all][
+            self.bh_mask_ap
+        ][self.iBHmax]
+
+    @lazy_property
+    def BHmaxID(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["ParticleIDs"][self.bh_mask_all][self.bh_mask_ap][
+            self.iBHmax
+        ]
+
+    @lazy_property
+    def BHmaxpos(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["Coordinates"][self.bh_mask_all][self.bh_mask_ap][
+            self.iBHmax
+        ]
+
+    @lazy_property
+    def BHmaxvel(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["Velocities"][self.bh_mask_all][self.bh_mask_ap][
+            self.iBHmax
+        ]
+
+    @lazy_property
+    def BHmaxAR(self):
+        if self.Nbh == 0:
+            return None
+        return self.data["PartType5"]["AccretionRates"][self.bh_mask_all][
+            self.bh_mask_ap
+        ][self.iBHmax]
+
+    @lazy_property
+    def BHmaxlasteventa(self):
+        if self.Nbh == 0:
+            return None
+        return self.agn_eventa[self.iBHmax]
+
+    @lazy_property
+    def mass_fraction(self):
+        if self.Mtot == 0:
+            return None
+        return self.mass / self.Mtot
+
+    @lazy_property
+    def com(self):
+        if self.Mtot == 0:
+            return None
+        return (self.mass_fraction[:, None] * self.position).sum(axis=0) + self.centre
+
+    @lazy_property
+    def vcom(self):
+        if self.Mtot == 0:
+            return None
+        return (self.mass_fraction[:, None] * self.velocity).sum(axis=0)
+
+    @lazy_property
+    def spin_parameter(self):
+        if self.Mtot == 0:
+            return None
+        _, vmax = get_vmax(self.mass, self.radius)
+        if vmax == 0:
+            return None
+        vrel = self.velocity - self.vcom[None, :]
+        Ltot = unyt.array.unorm(
+            (self.mass[:, None] * unyt.array.ucross(self.position, vrel)).sum(axis=0)
+        )
+        return Ltot / (np.sqrt(2.0) * self.Mtot * self.aperture_radius * vmax)
+
+    @lazy_property
+    def gas_mass_fraction(self):
+        if self.Mgas == 0:
+            return None
+        return self.mass_gas / self.Mgas
+
+    @lazy_property
+    def vcom_gas(self):
+        if self.Mgas == 0:
+            return None
+        return (self.gas_mass_fraction[:, None] * self.vel_gas).sum(axis=0)
+
+    def compute_Lgas_props(self):
+        (
+            self.internal_Lgas,
+            self.internal_kappa_gas,
+            self.internal_Mcountrot_gas,
+        ) = get_angular_momentum_and_kappa_corot(
+            self.mass_gas,
+            self.pos_gas,
+            self.vel_gas,
+            ref_velocity=self.vcom_gas,
+            do_counterrot_mass=True,
+        )
+
+    @lazy_property
+    def Lgas(self):
+        if self.Mgas == 0:
+            return None
+        if not hasattr(self, "internal_Lgas"):
+            self.compute_Lgas_props()
+        return self.internal_Lgas
+
+    @lazy_property
+    def kappa_corot_gas(self):
+        if self.Mgas == 0:
+            return None
+        if not hasattr(self, "internal_kappa_gas"):
+            self.compute_Lgas_props()
+        return self.internal_kappa_gas
+
+    @lazy_property
+    def DtoTgas(self):
+        if self.Mgas == 0:
+            return None
+        if not hasattr(self, "internal_Mcountrot_gas"):
+            self.compute_Lgas_props()
+        return 1.0 - 2.0 * self.internal_Mcountrot_gas / self.Mgas
+
+    @lazy_property
+    def Ekin_gas(self):
+        if self.Mgas == 0:
+            return None
+        # below we need to force conversion to np.float64 before summing
+        # up particles to avoid overflow
+        ekin_gas = self.mass_gas * ((self.vel_gas - self.vcom_gas) ** 2).sum(axis=1)
+        ekin_gas = unyt.unyt_array(
+            ekin_gas.value, dtype=np.float64, units=ekin_gas.units
+        )
+        return 0.5 * ekin_gas.sum()
+
+    @lazy_property
+    def GasAxisLengths(self):
+        return get_axis_lengths(self.mass_gas, self.pos_gas)
+
+    @lazy_property
+    def dm_mass_fraction(self):
+        if self.Mdm == 0:
+            return None
+        return self.mass_dm / self.Mdm
+
+    @lazy_property
+    def vcom_dm(self):
+        if self.Mdm == 0:
+            return None
+        return (self.dm_mass_fraction[:, None] * self.vel_dm).sum(axis=0)
+
+    @lazy_property
+    def Ldm(self):
+        if self.Mdm == 0:
+            return None
+        return get_angular_momentum(
+            self.mass_dm, self.pos_dm, self.vel_dm, ref_velocity=self.vcom_dm
+        )
+
+    @lazy_property
+    def DMAxisLengths(self):
+        return get_axis_lengths(self.mass_dm, self.pos_dm)
+
+    @lazy_property
+    def vcom_star(self):
+        if self.Mstar == 0:
+            return None
+        return (self.star_mass_fraction[:, None] * self.vel_star).sum(axis=0)
+
+    def compute_Lstar_props(self):
+        (
+            self.internal_Lstar,
+            self.internal_kappa_star,
+            self.internal_Mcountrot_star,
+        ) = get_angular_momentum_and_kappa_corot(
+            self.mass_star,
+            self.pos_star,
+            self.vel_star,
+            ref_velocity=self.vcom_star,
+            do_counterrot_mass=True,
+        )
+
+    @lazy_property
+    def Lstar(self):
+        if self.Mstar == 0:
+            return None
+        if not hasattr(self, "internal_Lstar"):
+            self.compute_Lstar_props()
+        return self.internal_Lstar
+
+    @lazy_property
+    def kappa_corot_star(self):
+        if self.Mstar == 0:
+            return None
+        if not hasattr(self, "internal_kappa_star"):
+            self.compute_Lstar_props()
+        return self.internal_kappa_star
+
+    @lazy_property
+    def DtoTstar(self):
+        if self.Mstar == 0:
+            return None
+        if not hasattr(self, "internal_Mcountrot_star"):
+            self.compute_Lstar_props()
+        return 1.0 - 2.0 * self.internal_Mcountrot_star / self.Mstar
+
+    @lazy_property
+    def StellarAxisLengths(self):
+        return get_axis_lengths(self.mass_star, self.pos_star)
+
+    @lazy_property
+    def Ekin_star(self):
+        if self.Mstar == 0:
+            return None
+        # below we need to force conversion to np.float64 before summing
+        # up particles to avoid overflow
+        ekin_star = self.mass_star * ((self.vel_star - self.vcom_star) ** 2).sum(axis=1)
+        ekin_star = unyt.unyt_array(
+            ekin_star.value, dtype=np.float64, units=ekin_star.units
+        )
+        return 0.5 * ekin_star.sum()
+
+    @lazy_property
+    def baryon_mass_fraction(self):
+        if self.Mbaryons == 0:
+            return None
+        return self.mass_baryons / self.Mbaryons
+
+    @lazy_property
+    def vcom_bar(self):
+        if self.Mbaryons == 0:
+            return None
+        return (self.baryon_mass_fraction[:, None] * self.vel_baryons).sum(axis=0)
+
+    def compute_Lbar_props(self):
+        (
+            self.internal_Lbar,
+            self.internal_kappa_bar,
+        ) = get_angular_momentum_and_kappa_corot(
+            self.mass_baryons,
+            self.pos_baryons,
+            self.vel_baryons,
+            ref_velocity=self.vcom_bar,
+        )
+
+    @lazy_property
+    def Lbaryons(self):
+        if self.Mbaryons == 0:
+            return None
+        if not hasattr(self, "internal_Lbar"):
+            self.compute_Lbar_props()
+        return self.internal_Lbar
+
+    @lazy_property
+    def kappa_corot_baryons(self):
+        if self.Mbaryons == 0:
+            return None
+        if not hasattr(self, "internal_kappa_bar"):
+            self.compute_Lbar_props()
+        return self.internal_kappa_bar
+
+    @lazy_property
+    def BaryonAxisLengths(self):
+        return get_axis_lengths(self.mass_baryons, self.pos_baryons)
+
+    @lazy_property
+    def gas_mask_all(self):
+        if self.Ngas == 0:
+            return None
+        if self.inclusive:
+            return np.ones(self.data["PartType0"]["GroupNr_bound"].shape, dtype=bool)
+        else:
+            return self.data["PartType0"]["GroupNr_bound"] == self.index
+
+    @lazy_property
+    def gas_SFR(self):
+        if self.Ngas == 0:
+            return None
+        raw_SFR = self.data["PartType0"]["StarFormationRates"][self.gas_mask_all][
+            self.gas_mask_ap
+        ]
+        # Negative SFR are not SFR at all!
+        raw_SFR[raw_SFR < 0] = 0
+        return raw_SFR
+
+    @lazy_property
+    def is_SFR(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_SFR > 0
+
+    @lazy_property
+    def SFR(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_SFR.sum()
+
+    @lazy_property
+    def Mgas_SF(self):
+        if self.Ngas == 0:
+            return None
+        return self.mass_gas[self.is_SFR].sum()
+
+    @lazy_property
+    def gas_Mgasmetal(self):
+        if self.Ngas == 0:
+            return None
+        return (
+            self.mass_gas
+            * self.data["PartType0"]["MetalMassFractions"][self.gas_mask_all][
+                self.gas_mask_ap
+            ]
+        )
+
+    @lazy_property
+    def Mgasmetal_SF(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_Mgasmetal[self.is_SFR].sum()
+
+    @lazy_property
+    def Mgasmetal(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_Mgasmetal.sum()
+
+    @lazy_property
+    def gas_MgasO(self):
+        if self.Ngas == 0:
+            return None
+        return (
+            self.mass_gas
+            * self.data["PartType0"]["SmoothedElementMassFractions"][self.gas_mask_all][
+                self.gas_mask_ap
+            ][:, indexO]
+        )
+
+    @lazy_property
+    def MgasO_SF(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_MgasO[self.is_SFR].sum()
+
+    @lazy_property
+    def MgasO(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_MgasO.sum()
+
+    @lazy_property
+    def gas_MgasFe(self):
+        if self.Ngas == 0:
+            return None
+        return (
+            self.mass_gas
+            * self.data["PartType0"]["SmoothedElementMassFractions"][self.gas_mask_all][
+                self.gas_mask_ap
+            ][:, indexFe]
+        )
+
+    @lazy_property
+    def MgasFe_SF(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_MgasFe[self.is_SFR].sum()
+
+    @lazy_property
+    def MgasFe(self):
+        if self.Ngas == 0:
+            return None
+        return self.gas_MgasFe.sum()
+
+    @lazy_property
+    def gas_temp(self):
+        if self.Ngas == 0:
+            return None
+        return self.data["PartType0"]["Temperatures"][self.gas_mask_all][
+            self.gas_mask_ap
+        ]
+
+    @lazy_property
+    def gas_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        last_agn_gas = self.data["PartType0"]["LastAGNFeedbackScaleFactors"][
+            self.gas_mask_all
+        ][self.gas_mask_ap]
+        return ~self.recently_heated_gas_filter.is_recently_heated(
+            last_agn_gas, self.gas_temp
+        )
+
+    @lazy_property
+    def Tgas(self):
+        if self.Mgas == 0 or self.Ngas == 0:
+            return None
+        return (self.gas_mass_fraction * self.gas_temp).sum()
+
+    @lazy_property
+    def Tgas_no_agn(self):
+        if self.Ngas == 0:
+            return None
+        if np.any(self.gas_no_agn):
+            mass_gas_no_agn = self.mass_gas[self.gas_no_agn]
+            Mgas_no_agn = mass_gas_no_agn.sum()
+            if Mgas_no_agn > 0:
+                return (
+                    (mass_gas_no_agn / Mgas_no_agn) * self.gas_temp[self.gas_no_agn]
+                ).sum()
+        return None
+
+    @lazy_property
+    def HalfMassRadiusGas(self):
+        return get_half_mass_radius(
+            self.radius[self.type == "PartType0"], self.mass_gas, self.Mgas
+        )
+
+    @lazy_property
+    def HalfMassRadiusDM(self):
+        return get_half_mass_radius(
+            self.radius[self.type == "PartType1"], self.mass_dm, self.Mdm
+        )
+
+    @lazy_property
+    def HalfMassRadiusStar(self):
+        return get_half_mass_radius(
+            self.radius[self.type == "PartType4"], self.mass_star, self.Mstar
+        )
+
+    @lazy_property
+    def HalfMassRadiusBaryon(self):
+        return get_half_mass_radius(
+            self.radius[(self.type == "PartType0") | (self.type == "PartType4")],
+            self.mass_baryons,
+            self.Mbaryons,
+        )
 
 
 class ApertureProperties(HaloProperty):
@@ -183,37 +954,39 @@ class ApertureProperties(HaloProperty):
         Input particle data arrays are unyt_arrays.
         """
 
-        centre = input_halo["cofp"]
-        index = input_halo["index"]
-
         types_present = [type for type in self.particle_properties if type in data]
 
-        mass = []
-        position = []
-        radius = []
-        velocity = []
-        types = []
-        for ptype in types_present:
-            grnr = data[ptype]["GroupNr_bound"]
-            if self.inclusive:
-                in_halo = np.ones(grnr.shape, dtype=bool)
-            else:
-                in_halo = grnr == index
-            mass.append(data[ptype][mass_dataset(ptype)][in_halo])
-            pos = data[ptype]["Coordinates"][in_halo, :] - centre[None, :]
-            position.append(pos)
-            r = np.sqrt(pos[:, 0] ** 2 + pos[:, 1] ** 2 + pos[:, 2] ** 2)
-            radius.append(r)
-            velocity.append(data[ptype]["Velocities"][in_halo, :])
-            typearr = np.zeros(r.shape, dtype="U9")
-            typearr[:] = ptype
-            types.append(typearr)
+        part_props = ApertureParticleData(
+            input_halo,
+            data,
+            types_present,
+            self.inclusive,
+            self.physical_radius_mpc * unyt.Mpc,
+            self.stellar_ages,
+            self.filter,
+        )
 
-        mass = unyt.array.uconcatenate(mass)
-        position = unyt.array.uconcatenate(position)
-        radius = unyt.array.uconcatenate(radius)
-        velocity = unyt.array.uconcatenate(velocity)
-        types = np.concatenate(types)
+        Ngas = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}"
+        ][0].value
+        Ndm = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}"
+        ][0].value
+        Nstar = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}"
+        ][0].value
+        Nbh = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}"
+        ][0].value
+
+        do_calculation = {
+            "basic": True,
+            "general": Ngas + Ndm + Nstar + Nbh > 100,
+            "gas": Ngas > 50,
+            "dm": Ndm > 100,
+            "star": Nstar > 50,
+            "baryon": Ngas + Nstar > 100,
+        }
 
         aperture_sphere = {}
         # declare all the variables we will compute
@@ -221,347 +994,27 @@ class ApertureProperties(HaloProperty):
         # all variables are defined with physical units and an appropriate dtype
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
-        for name, _, shape, dtype, unit, _, _, _ in self.property_list:
+        registry = part_props.mass.units.registry
+        for name, _, shape, dtype, unit, _, category, _ in self.property_list:
             if shape > 1:
                 val = [0] * shape
             else:
                 val = 0
             aperture_sphere[name] = unyt.unyt_array(
-                val, dtype=dtype, units=unit, registry=mass.units.registry
+                val, dtype=dtype, units=unit, registry=registry
             )
-
-        mask = radius <= self.physical_radius_mpc * unyt.Mpc
-
-        mass = mass[mask]
-        position = position[mask]
-        velocity = velocity[mask]
-        radius = radius[mask]
-        type = types[mask]
-
-        gas_mask_ap = mask[types == "PartType0"]
-        dm_mask_ap = mask[types == "PartType1"]
-        star_mask_ap = mask[types == "PartType4"]
-        bh_mask_ap = mask[types == "PartType5"]
-        baryons_mask_ap = mask[(types == "PartType0") | (types == "PartType4")]
-
-        aperture_sphere["Ngas"] = (
-            gas_mask_ap.sum(dtype=aperture_sphere["Ngas"].dtype)
-            * aperture_sphere["Ngas"].units
-        )
-        aperture_sphere["Ndm"] = (
-            dm_mask_ap.sum(dtype=aperture_sphere["Ndm"].dtype)
-            * aperture_sphere["Ndm"].units
-        )
-        aperture_sphere["Nstar"] = (
-            star_mask_ap.sum(dtype=aperture_sphere["Nstar"].dtype)
-            * aperture_sphere["Nstar"].units
-        )
-        aperture_sphere["Nbh"] = (
-            bh_mask_ap.sum(dtype=aperture_sphere["Nbh"].dtype)
-            * aperture_sphere["Nbh"].units
-        )
-
-        mass_gas = mass[type == "PartType0"]
-        mass_dm = mass[type == "PartType1"]
-        mass_star = mass[type == "PartType4"]
-        mass_baryons = mass[(type == "PartType0") | (type == "PartType4")]
-
-        pos_gas = position[type == "PartType0"]
-        pos_dm = position[type == "PartType1"]
-        pos_star = position[type == "PartType4"]
-        pos_baryons = position[(type == "PartType0") | (type == "PartType4")]
-
-        vel_gas = velocity[type == "PartType0"]
-        vel_dm = velocity[type == "PartType1"]
-        vel_star = velocity[type == "PartType4"]
-        vel_baryons = velocity[(type == "PartType0") | (type == "PartType4")]
-
-        aperture_sphere["Mtot"] += mass.sum()
-        aperture_sphere["Mgas"] += mass_gas.sum()
-        aperture_sphere["Mdm"] = mass_dm.sum()
-        aperture_sphere["Mstar"] += mass_star.sum()
-        if aperture_sphere["Nstar"] > 0:
-            if self.inclusive:
-                star_mask_all = np.ones(
-                    data["PartType4"]["GroupNr_bound"].shape, dtype=bool
-                )
-            else:
-                star_mask_all = data["PartType4"]["GroupNr_bound"] == index
-            aperture_sphere["Mstar_init"] += data["PartType4"]["InitialMasses"][
-                star_mask_all
-            ][star_mask_ap].sum()
-            luminosities = data["PartType4"]["Luminosities"][star_mask_all][
-                star_mask_ap
-            ]
-            aperture_sphere["StellarLuminosity"] += luminosities.sum(axis=0)
-            aperture_sphere["Mstarmetal"] += (
-                mass_star
-                * data["PartType4"]["MetalMassFractions"][star_mask_all][star_mask_ap]
-            ).sum()
-            MstarO = (
-                mass_star
-                * data["PartType4"]["SmoothedElementMassFractions"][star_mask_all][
-                    star_mask_ap
-                ][:, indexO]
-            )
-            aperture_sphere["MstarO"] += MstarO.sum()
-            MstarFe = (
-                mass_star
-                * data["PartType4"]["SmoothedElementMassFractions"][star_mask_all][
-                    star_mask_ap
-                ][:, indexFe]
-            )
-            aperture_sphere["MstarFe"] += MstarFe.sum()
-            birth_a = data["PartType4"]["BirthScaleFactors"][star_mask_all][
-                star_mask_ap
-            ]
-            stellar_ages = self.stellar_ages.stellar_age(birth_a)
-            aperture_sphere["stellar_age_mw"] += (
-                (mass_star / aperture_sphere["Mstar"]) * stellar_ages
-            ).sum()
-            Lr = luminosities[:, rbandindex]
-            Lrtot = Lr.sum()
-            aperture_sphere["stellar_age_lw"] += ((Lr / Lrtot) * stellar_ages).sum()
-        aperture_sphere["Mbh_dynamical"] = mass[type == "PartType5"].sum()
-        if aperture_sphere["Nbh"] > 0:
-            if self.inclusive:
-                bh_mask_all = np.ones(
-                    data["PartType5"]["GroupNr_bound"].shape, dtype=bool
-                )
-            else:
-                bh_mask_all = data["PartType5"]["GroupNr_bound"] == index
-            aperture_sphere["Mbh_subgrid"] += data["PartType5"]["SubgridMasses"][
-                bh_mask_all
-            ][bh_mask_ap].sum()
-
-            agn_eventa = data["PartType5"]["LastAGNFeedbackScaleFactors"][bh_mask_all][
-                bh_mask_ap
-            ]
-
-            aperture_sphere["BHlasteventa"] += np.max(agn_eventa)
-
-            iBHmax = np.argmax(
-                data["PartType5"]["SubgridMasses"][bh_mask_all][bh_mask_ap]
-            )
-            aperture_sphere["BHmaxM"] += data["PartType5"]["SubgridMasses"][
-                bh_mask_all
-            ][bh_mask_ap][iBHmax]
-            aperture_sphere["BHmaxID"] = (
-                data["PartType5"]["ParticleIDs"][bh_mask_all][bh_mask_ap][
-                    iBHmax
-                ].astype(aperture_sphere["BHmaxID"].dtype)
-                * aperture_sphere["BHmaxID"].units
-            )
-            aperture_sphere["BHmaxpos"] += data["PartType5"]["Coordinates"][
-                bh_mask_all
-            ][bh_mask_ap][iBHmax]
-            aperture_sphere["BHmaxvel"] += data["PartType5"]["Velocities"][bh_mask_all][
-                bh_mask_ap
-            ][iBHmax]
-            aperture_sphere["BHmaxAR"] += data["PartType5"]["AccretionRates"][
-                bh_mask_all
-            ][bh_mask_ap][iBHmax]
-            aperture_sphere["BHmaxlasteventa"] += agn_eventa[iBHmax]
-
-        if aperture_sphere["Mtot"] > 0.0 * aperture_sphere["Mtot"].units:
-            mfrac = mass / aperture_sphere["Mtot"]
-            aperture_sphere["com"] += (mfrac[:, None] * position).sum(axis=0)
-            aperture_sphere["com"] += centre
-            aperture_sphere["vcom"] += (mfrac[:, None] * velocity).sum(axis=0)
-            _, vmax = get_vmax(mass, radius)
-            if vmax > 0.0 * vmax.units:
-                vrel = velocity - aperture_sphere["vcom"][None, :]
-                Ltot = unyt.array.unorm(
-                    (mass[:, None] * unyt.array.ucross(position, vrel)).sum(axis=0)
-                )
-                aperture_sphere["spin_parameter"] += Ltot / (
-                    np.sqrt(2.0)
-                    * aperture_sphere["Mtot"]
-                    * self.physical_radius_mpc
-                    * unyt.Mpc
-                    * vmax
-                )
-
-        if aperture_sphere["Mgas"] > 0.0 * aperture_sphere["Mgas"].units:
-            frac_mgas = mass_gas / aperture_sphere["Mgas"]
-            vcom_gas = (frac_mgas[:, None] * vel_gas).sum(axis=0)
-            Lgas, kappa, Mcountrot = get_angular_momentum_and_kappa_corot(
-                mass_gas,
-                pos_gas,
-                vel_gas,
-                ref_velocity=vcom_gas,
-                do_counterrot_mass=True,
-            )
-            aperture_sphere["Lgas"] += Lgas
-            aperture_sphere["kappa_corot_gas"] += kappa
-            aperture_sphere["DtoTgas"] += (
-                1.0 - 2.0 * Mcountrot / aperture_sphere["Mgas"]
-            )
-
-            """
-            aperture_sphere["veldisp_matrix_gas"] += get_velocity_dispersion_matrix(
-                frac_mgas, vel_gas, vcom_gas
-            )
-            """
-
-            # below we need to force conversion to np.float64 before summing
-            # up particles to avoid overflow
-            ekin_gas = mass_gas * ((vel_gas - vcom_gas) ** 2).sum(axis=1)
-            ekin_gas = unyt.unyt_array(
-                ekin_gas.value, dtype=np.float64, units=ekin_gas.units
-            )
-            aperture_sphere["Ekin_gas"] += 0.5 * ekin_gas.sum()
-
-            aperture_sphere["GasAxisLengths"] += get_axis_lengths(mass_gas, pos_gas)
-
-        if aperture_sphere["Mdm"] > 0.0 * aperture_sphere["Mdm"].units:
-            frac_mdm = mass_dm / aperture_sphere["Mdm"]
-            vcom_dm = (frac_mdm[:, None] * vel_dm).sum(axis=0)
-            aperture_sphere["Ldm"] += get_angular_momentum(
-                mass_dm, pos_dm, vel_dm, ref_velocity=vcom_dm
-            )
-            aperture_sphere["DMAxisLengths"] += get_axis_lengths(mass_dm, pos_dm)
-
-            """
-            aperture_sphere["veldisp_matrix_dm"] += get_velocity_dispersion_matrix(
-                frac_mdm, vel_dm, vcom_dm
-            )
-            """
-
-        if aperture_sphere["Mstar"] > 0.0 * aperture_sphere["Mstar"].units:
-            frac_mstar = mass_star / aperture_sphere["Mstar"]
-            vcom_star = (frac_mstar[:, None] * vel_star).sum(axis=0)
-            Lstar, kappa, Mcountrot = get_angular_momentum_and_kappa_corot(
-                mass_star,
-                pos_star,
-                vel_star,
-                ref_velocity=vcom_star,
-                do_counterrot_mass=True,
-            )
-            aperture_sphere["Lstar"] += Lstar
-            aperture_sphere["kappa_corot_star"] += kappa
-            aperture_sphere["DtoTstar"] += (
-                1.0 - 2.0 * Mcountrot / aperture_sphere["Mstar"]
-            )
-            aperture_sphere["StellarAxisLengths"] += get_axis_lengths(
-                mass_star, pos_star
-            )
-
-            """
-            aperture_sphere["veldisp_matrix_star"] += get_velocity_dispersion_matrix(
-                frac_mstar, vel_star, vcom_star
-            )
-            """
-
-            # below we need to force conversion to np.float64 before summing
-            # up particles to avoid overflow
-            ekin_star = mass_star * ((vel_star - vcom_star) ** 2).sum(axis=1)
-            ekin_star = unyt.unyt_array(
-                ekin_star.value, dtype=np.float64, units=ekin_star.units
-            )
-            aperture_sphere["Ekin_star"] += 0.5 * ekin_star.sum()
-
-        if (
-            aperture_sphere["Mgas"] + aperture_sphere["Mstar"]
-            > 0.0 * aperture_sphere["Mgas"].units
-        ):
-            frac_mbar = mass_baryons / (
-                aperture_sphere["Mgas"] + aperture_sphere["Mstar"]
-            )
-            vcom_bar = (frac_mbar[:, None] * vel_baryons).sum(axis=0)
-            Lbar, kappa = get_angular_momentum_and_kappa_corot(
-                mass_baryons, pos_baryons, vel_baryons, ref_velocity=vcom_bar
-            )
-            aperture_sphere["Lbaryons"] += Lbar
-            aperture_sphere["kappa_corot_baryons"] += kappa
-            aperture_sphere["BaryonAxisLengths"] += get_axis_lengths(
-                mass_baryons, pos_baryons
-            )
-
-        if aperture_sphere["Ngas"] > 0:
-            if self.inclusive:
-                gas_mask_all = np.ones(
-                    data["PartType0"]["GroupNr_bound"].shape, dtype=bool
-                )
-            else:
-                gas_mask_all = data["PartType0"]["GroupNr_bound"] == index
-            SFR = data["PartType0"]["StarFormationRates"][gas_mask_all][gas_mask_ap]
-            # negative values of SFR are not SFR at all!
-            is_SFR = SFR > 0.0
-            aperture_sphere["SFR"] += SFR[is_SFR].sum()
-            aperture_sphere["Mgas_SF"] += mass_gas[is_SFR].sum()
-            Mgasmetal = (
-                mass_gas
-                * data["PartType0"]["MetalMassFractions"][gas_mask_all][gas_mask_ap]
-            )
-            aperture_sphere["Mgasmetal_SF"] += Mgasmetal[is_SFR].sum()
-            aperture_sphere["Mgasmetal"] += Mgasmetal.sum()
-            MgasO = (
-                mass_gas
-                * data["PartType0"]["SmoothedElementMassFractions"][gas_mask_all][
-                    gas_mask_ap
-                ][:, indexO]
-            )
-            aperture_sphere["MgasO_SF"] += MgasO[is_SFR].sum()
-            aperture_sphere["MgasO"] += MgasO.sum()
-            MgasFe = (
-                mass_gas
-                * data["PartType0"]["SmoothedElementMassFractions"][gas_mask_all][
-                    gas_mask_ap
-                ][:, indexFe]
-            )
-            aperture_sphere["MgasFe_SF"] += MgasFe[is_SFR].sum()
-            aperture_sphere["MgasFe"] += MgasFe.sum()
-            gas_temp = data["PartType0"]["Temperatures"][gas_mask_all][gas_mask_ap]
-            last_agn_gas = data["PartType0"]["LastAGNFeedbackScaleFactors"][
-                gas_mask_all
-            ][gas_mask_ap]
-            no_agn = ~self.filter.is_recently_heated(last_agn_gas, gas_temp)
-            aperture_sphere["Tgas"] += (
-                (mass_gas / aperture_sphere["Mgas"]) * gas_temp
-            ).sum()
-            if np.any(no_agn):
-                mass_gas_no_agn = mass_gas[no_agn]
-                Mgas_no_agn = mass_gas_no_agn.sum()
-                if Mgas_no_agn > 0.0:
-                    aperture_sphere["Tgas_no_agn"] += (
-                        (mass_gas_no_agn / Mgas_no_agn) * gas_temp[no_agn]
-                    ).sum()
-
-        for name, r, m, M in zip(
-            [
-                "HalfMassRadiusGas",
-                "HalfMassRadiusDM",
-                "HalfMassRadiusStar",
-                "HalfMassRadiusBaryon",
-            ],
-            [
-                radius[type == "PartType0"],
-                radius[type == "PartType1"],
-                radius[type == "PartType4"],
-                radius[(type == "PartType0") | (type == "PartType4")],
-            ],
-            [
-                mass_gas,
-                mass_dm,
-                mass_star,
-                mass[(type == "PartType0") | (type == "PartType4")],
-            ],
-            [
-                aperture_sphere["Mgas"],
-                aperture_sphere["Mdm"],
-                aperture_sphere["Mstar"],
-                aperture_sphere["Mgas"] + aperture_sphere["Mstar"],
-            ],
-        ):
-            aperture_sphere[name] += get_half_mass_radius(r, m, M)
-            if aperture_sphere[name] >= self.physical_radius_mpc * unyt.Mpc:
-                raise RuntimeError(
-                    "Half mass radius '{name}' larger than aperture"
-                    f" ({aperture_sphere[name]} >="
-                    f" {self.physical_radius_mpc * unyt.Mpc}!"
-                    " This should not happen."
-                )
+            if do_calculation[category]:
+                val = getattr(part_props, name)
+                if val is not None:
+                    if unit == "dimensionless":
+                        aperture_sphere[name] = unyt.unyt_array(
+                            val.astype(dtype),
+                            dtype=dtype,
+                            units=unit,
+                            registry=registry,
+                        )
+                    else:
+                        aperture_sphere[name] += val
 
         if self.inclusive:
             prefix = f"InclusiveSphere/{self.physical_radius_mpc*1000.:.0f}kpc"
@@ -640,9 +1093,43 @@ def test_aperture_properties():
 
     # generate 100 random halos
     for i in range(100):
-        input_halo, data, _, _, _ = dummy_halos.get_random_halo(
+        input_halo, data, _, _, _, particle_numbers = dummy_halos.get_random_halo(
             [1, 10, 100, 1000, 10000]
         )
+        halo_result_template = {
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType0"],
+                    dtype=PropertyTable.full_property_list["Ngas"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Ngas for filter",
+            ),
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType1"],
+                    dtype=PropertyTable.full_property_list["Ndm"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Ndm for filter",
+            ),
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType4"],
+                    dtype=PropertyTable.full_property_list["Nstar"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Nstar for filter",
+            ),
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}": (
+                unyt.unyt_array(
+                    particle_numbers["PartType5"],
+                    dtype=PropertyTable.full_property_list["Nbh"][2],
+                    units="dimensionless",
+                ),
+                "Dummy Nbh for filter",
+            ),
+        }
 
         for pc_type, pc_calc in [
             ("ExclusiveSphere", pc_exclusive),
@@ -656,7 +1143,7 @@ def test_aperture_properties():
                         input_data[ptype][dset] = data[ptype][dset]
             input_halo_copy = input_halo.copy()
             input_data_copy = input_data.copy()
-            halo_result = {}
+            halo_result = dict(halo_result_template)
             pc_calc.calculate(input_halo, 0.0 * unyt.kpc, input_data, halo_result)
             assert input_halo == input_halo_copy
             assert input_data == input_data_copy

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -25,20 +25,6 @@ indexFe = 8
 rbandindex = 2
 
 
-def set_halo_property(prop_dict, name, part_props):
-    prop_info = PropertyTable.full_property_list[name]
-    dtype = prop_info[2]
-    units = prop_info[3]
-    val = getattr(part_props, name)
-    if val is not None:
-        if units == "dimensionless":
-            prop_dict[name] = unyt.unyt_array(
-                val.astype(dtype), dtype=dtype, units=units
-            )
-        else:
-            prop_dict[name] += val
-
-
 class ApertureParticleData:
     def __init__(
         self,

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -973,6 +973,10 @@ class ApertureProperties(HaloProperty):
         # back to snapshot units in the end
         registry = part_props.mass.units.registry
         for prop in self.property_list:
+            # skip non-DMO properties in DMO run mode
+            is_dmo = prop[8]
+            if do_calculation["DMO"] and not is_dmo:
+                continue
             name = prop[0]
             shape = prop[2]
             dtype = prop[3]
@@ -1003,6 +1007,10 @@ class ApertureProperties(HaloProperty):
         else:
             prefix = f"ExclusiveSphere/{self.physical_radius_mpc*1000.:.0f}kpc"
         for prop in self.property_list:
+            # skip non-DMO properties in DMO run mode
+            is_dmo = prop[8]
+            if do_calculation["DMO"] and not is_dmo:
+                continue
             name = prop[0]
             outputname = prop[1]
             description = prop[5]

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -127,6 +127,8 @@ class ApertureProperties(HaloProperty):
             "DtoTstar",
             "MstarO",
             "MstarFe",
+            "stellar_age_mw",
+            "stellar_age_lw",
         ]
     ]
 

--- a/aperture_properties.py
+++ b/aperture_properties.py
@@ -481,6 +481,8 @@ class ApertureParticleData:
 
     @lazy_property
     def GasAxisLengths(self):
+        if self.Mgas == 0:
+            return None
         return get_axis_lengths(self.mass_gas, self.pos_gas)
 
     @lazy_property
@@ -505,6 +507,8 @@ class ApertureParticleData:
 
     @lazy_property
     def DMAxisLengths(self):
+        if self.Mdm == 0:
+            return None
         return get_axis_lengths(self.mass_dm, self.pos_dm)
 
     @lazy_property
@@ -552,6 +556,8 @@ class ApertureParticleData:
 
     @lazy_property
     def StellarAxisLengths(self):
+        if self.Mstar == 0:
+            return None
         return get_axis_lengths(self.mass_star, self.pos_star)
 
     @lazy_property
@@ -607,6 +613,8 @@ class ApertureParticleData:
 
     @lazy_property
     def BaryonAxisLengths(self):
+        if self.Mbaryons == 0:
+            return None
         return get_axis_lengths(self.mass_baryons, self.pos_baryons)
 
     @lazy_property

--- a/category_filter.py
+++ b/category_filter.py
@@ -40,16 +40,21 @@ class CategoryFilter:
         }
 
     def get_filters(self, halo_result):
-        Ngas = halo_result[
-            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}"
-        ][0].value
         Ndm = halo_result[
             f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}"
         ][0].value
-        Nstar = halo_result[
-            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}"
-        ][0].value
-        Nbh = halo_result[
-            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}"
-        ][0].value
+        if self.dmo:
+            Ngas = 0
+            Nstar = 0
+            Nbh = 0
+        else:
+            Ngas = halo_result[
+                f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}"
+            ][0].value
+            Nstar = halo_result[
+                f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}"
+            ][0].value
+            Nbh = halo_result[
+                f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}"
+            ][0].value
         return self.get_filters_direct(Ngas, Ndm, Nstar, Nbh)

--- a/category_filter.py
+++ b/category_filter.py
@@ -19,12 +19,14 @@ class CategoryFilter:
         Ndm=100,
         Nstar=50,
         Nbaryon=100,
+        dmo=False,
     ):
         self.Ngeneral = Ngeneral
         self.Ngas = Ngas
         self.Ndm = Ndm
         self.Nstar = Nstar
         self.Nbaryon = Nbaryon
+        self.dmo = dmo
 
     def get_filters_direct(self, Ngas, Ndm, Nstar, Nbh):
         return {
@@ -34,6 +36,7 @@ class CategoryFilter:
             "dm": Ndm > self.Ndm,
             "star": Nstar > self.Nstar,
             "baryon": Ngas + Nstar > self.Nbaryon,
+            "DMO": self.dmo,
         }
 
     def get_filters(self, halo_result):

--- a/category_filter.py
+++ b/category_filter.py
@@ -1,0 +1,52 @@
+#!/bin/env python
+
+from property_table import PropertyTable
+
+
+class CategoryFilter:
+    """
+    Filter used to determine whether properties need to be calculated for a
+    certain halo or not.
+
+    This decision is always based on the number of particles in the 6D FOF
+    group, and requires the calculation of FOFSubhaloProperties for each halo.
+    """
+
+    def __init__(
+        self,
+        Ngeneral=100,
+        Ngas=50,
+        Ndm=100,
+        Nstar=50,
+        Nbaryon=100,
+    ):
+        self.Ngeneral = Ngeneral
+        self.Ngas = Ngas
+        self.Ndm = Ndm
+        self.Nstar = Nstar
+        self.Nbaryon = Nbaryon
+
+    def get_filters_direct(self, Ngas, Ndm, Nstar, Nbh):
+        return {
+            "basic": True,
+            "general": Ngas + Ndm + Nstar + Nbh > self.Ngeneral,
+            "gas": Ngas > self.Ngas,
+            "dm": Ndm > self.Ndm,
+            "star": Nstar > self.Nstar,
+            "baryon": Ngas + Nstar > self.Nbaryon,
+        }
+
+    def get_filters(self, halo_result):
+        Ngas = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ngas'][0]}"
+        ][0].value
+        Ndm = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Ndm'][0]}"
+        ][0].value
+        Nstar = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nstar'][0]}"
+        ][0].value
+        Nbh = halo_result[
+            f"FOFSubhaloProperties/{PropertyTable.full_property_list['Nbh'][0]}"
+        ][0].value
+        return self.get_filters_direct(Ngas, Ndm, Nstar, Nbh)

--- a/command_line_args.py
+++ b/command_line_args.py
@@ -37,6 +37,7 @@ def get_halo_props_args(comm):
         parser.add_argument("--extra-input", metavar="FORMAT_STRING",
                             help="Format string to generate names of files with additional particle datasets (e.g. halo membership). Use %%(file_nr)d for the file number and %%(snap_nr)04d for the snapshot.")
         parser.add_argument("--centrals-only", action="store_true", help="Only process central halos")
+        parser.add_argument("--dmo", action="store_true", help="Run in dark matter only mode")
         parser.add_argument("--max-halos", metavar="N", nargs=1, type=int, default=(0,),
                             help="(For debugging) only process the first N halos in the catalogue")
         parser.add_argument("--calculations", nargs="*", help="Which calculations to do (default is to do all)")

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -37,6 +37,7 @@ import result_set
 import projected_aperture_properties
 from recently_heated_gas_filter import RecentlyHeatedGasFilter
 from stellar_age_calculator import StellarAgeCalculator
+from category_filter import CategoryFilter
 
 
 def split_comm_world():
@@ -135,6 +136,9 @@ def compute_halo_properties():
         cellgrid, 15.0 * unyt.Myr, 0.0, 0.0
     )
     stellar_age_calculator = StellarAgeCalculator(cellgrid)
+    category_filter = CategoryFilter(
+        Ngeneral=100, Ngas=50, Ndm=100, Nstar=50, Nbaryon=100
+    )
 
     # Get the full list of property calculations we can do
     # Note that the order matters: we need to do the FOFSubhaloProperties first,
@@ -146,80 +150,171 @@ def compute_halo_properties():
             cellgrid,
             recently_heated_gas_filter,
             stellar_age_calculator,
+            category_filter,
             bound_only=False,
         ),
         subhalo_properties.SubhaloProperties(
             cellgrid,
             recently_heated_gas_filter,
             stellar_age_calculator,
+            category_filter,
             bound_only=True,
         ),
-        SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 200.0, "mean"),
-        SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 50.0, "crit"),
-        SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 100.0, "crit"),
-        SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 200.0, "crit"),
-        SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 500.0, "crit"),
         SO_properties.SOProperties(
-            cellgrid, recently_heated_gas_filter, 1000.0, "crit"
+            cellgrid, recently_heated_gas_filter, category_filter, 200.0, "mean"
         ),
         SO_properties.SOProperties(
-            cellgrid, recently_heated_gas_filter, 2500.0, "crit"
+            cellgrid, recently_heated_gas_filter, category_filter, 50.0, "crit"
         ),
-        SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 0.0, "BN98"),
+        SO_properties.SOProperties(
+            cellgrid, recently_heated_gas_filter, category_filter, 100.0, "crit"
+        ),
+        SO_properties.SOProperties(
+            cellgrid, recently_heated_gas_filter, category_filter, 200.0, "crit"
+        ),
+        SO_properties.SOProperties(
+            cellgrid, recently_heated_gas_filter, category_filter, 500.0, "crit"
+        ),
+        SO_properties.SOProperties(
+            cellgrid, recently_heated_gas_filter, category_filter, 1000.0, "crit"
+        ),
+        SO_properties.SOProperties(
+            cellgrid, recently_heated_gas_filter, category_filter, 2500.0, "crit"
+        ),
+        SO_properties.SOProperties(
+            cellgrid, recently_heated_gas_filter, category_filter, 0.0, "BN98"
+        ),
         SO_properties.RadiusMultipleSOProperties(
-            cellgrid, recently_heated_gas_filter, 500.0, 5.0, type="crit"
+            cellgrid,
+            recently_heated_gas_filter,
+            category_filter,
+            500.0,
+            5.0,
+            type="crit",
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 10.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            10.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 30.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            30.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 50.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            50.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 100.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            100.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 300.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            300.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 500.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            500.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 1000.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            1000.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 3000.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            3000.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
-        projected_aperture_properties.ProjectedApertureProperties(cellgrid, 10.0),
-        projected_aperture_properties.ProjectedApertureProperties(cellgrid, 30.0),
-        projected_aperture_properties.ProjectedApertureProperties(cellgrid, 50.0),
-        projected_aperture_properties.ProjectedApertureProperties(cellgrid, 100.0),
-        aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 10.0, recently_heated_gas_filter, stellar_age_calculator
+        projected_aperture_properties.ProjectedApertureProperties(
+            cellgrid, 10.0, category_filter
         ),
-        aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 30.0, recently_heated_gas_filter, stellar_age_calculator
+        projected_aperture_properties.ProjectedApertureProperties(
+            cellgrid, 30.0, category_filter
         ),
-        aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 50.0, recently_heated_gas_filter, stellar_age_calculator
+        projected_aperture_properties.ProjectedApertureProperties(
+            cellgrid, 50.0, category_filter
         ),
-        aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 100.0, recently_heated_gas_filter, stellar_age_calculator
-        ),
-        aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 300.0, recently_heated_gas_filter, stellar_age_calculator
+        projected_aperture_properties.ProjectedApertureProperties(
+            cellgrid, 100.0, category_filter
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 500.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            10.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 1000.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            30.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 3000.0, recently_heated_gas_filter, stellar_age_calculator
+            cellgrid,
+            50.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
+        ),
+        aperture_properties.ExclusiveSphereProperties(
+            cellgrid,
+            100.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
+        ),
+        aperture_properties.ExclusiveSphereProperties(
+            cellgrid,
+            300.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
+        ),
+        aperture_properties.ExclusiveSphereProperties(
+            cellgrid,
+            500.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
+        ),
+        aperture_properties.ExclusiveSphereProperties(
+            cellgrid,
+            1000.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
+        ),
+        aperture_properties.ExclusiveSphereProperties(
+            cellgrid,
+            3000.0,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            category_filter,
         ),
     ]
 

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -137,7 +137,7 @@ def compute_halo_properties():
     )
     stellar_age_calculator = StellarAgeCalculator(cellgrid)
     category_filter = CategoryFilter(
-        Ngeneral=100, Ngas=50, Ndm=100, Nstar=50, Nbaryon=100, args.dmo
+        Ngeneral=100, Ngas=50, Ndm=100, Nstar=50, Nbaryon=100, dmo=args.dmo
     )
 
     # Get the full list of property calculations we can do

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -137,7 +137,7 @@ def compute_halo_properties():
     )
     stellar_age_calculator = StellarAgeCalculator(cellgrid)
     category_filter = CategoryFilter(
-        Ngeneral=100, Ngas=50, Ndm=100, Nstar=50, Nbaryon=100, dmo=args.dmo
+        Ngeneral=100, Ngas=100, Ndm=100, Nstar=100, Nbaryon=100, dmo=args.dmo
     )
 
     # Get the full list of property calculations we can do

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -36,6 +36,7 @@ import aperture_properties
 import result_set
 import projected_aperture_properties
 from recently_heated_gas_filter import RecentlyHeatedGasFilter
+from stellar_age_calculator import StellarAgeCalculator
 
 
 def split_comm_world():
@@ -133,14 +134,21 @@ def compute_halo_properties():
     recently_heated_gas_filter = RecentlyHeatedGasFilter(
         cellgrid, 15.0 * unyt.Myr, 0.0, 0.0
     )
+    stellar_age_calculator = StellarAgeCalculator(cellgrid)
 
     # Get the full list of property calculations we can do
     halo_prop_list = [
         subhalo_properties.SubhaloProperties(
-            cellgrid, recently_heated_gas_filter, bound_only=True
+            cellgrid,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            bound_only=True,
         ),
         subhalo_properties.SubhaloProperties(
-            cellgrid, recently_heated_gas_filter, bound_only=False
+            cellgrid,
+            recently_heated_gas_filter,
+            stellar_age_calculator,
+            bound_only=False,
         ),
         SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 200.0, "mean"),
         SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 50.0, "crit"),
@@ -158,56 +166,56 @@ def compute_halo_properties():
             cellgrid, recently_heated_gas_filter, 500.0, 5.0, type="crit"
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 10.0, recently_heated_gas_filter
+            cellgrid, 10.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 30.0, recently_heated_gas_filter
+            cellgrid, 30.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 50.0, recently_heated_gas_filter
+            cellgrid, 50.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 100.0, recently_heated_gas_filter
+            cellgrid, 100.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 300.0, recently_heated_gas_filter
+            cellgrid, 300.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 500.0, recently_heated_gas_filter
+            cellgrid, 500.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 1000.0, recently_heated_gas_filter
+            cellgrid, 1000.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.InclusiveSphereProperties(
-            cellgrid, 3000.0, recently_heated_gas_filter
+            cellgrid, 3000.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         projected_aperture_properties.ProjectedApertureProperties(cellgrid, 10.0),
         projected_aperture_properties.ProjectedApertureProperties(cellgrid, 30.0),
         projected_aperture_properties.ProjectedApertureProperties(cellgrid, 50.0),
         projected_aperture_properties.ProjectedApertureProperties(cellgrid, 100.0),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 10.0, recently_heated_gas_filter
+            cellgrid, 10.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 30.0, recently_heated_gas_filter
+            cellgrid, 30.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 50.0, recently_heated_gas_filter
+            cellgrid, 50.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 100.0, recently_heated_gas_filter
+            cellgrid, 100.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 300.0, recently_heated_gas_filter
+            cellgrid, 300.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 500.0, recently_heated_gas_filter
+            cellgrid, 500.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 1000.0, recently_heated_gas_filter
+            cellgrid, 1000.0, recently_heated_gas_filter, stellar_age_calculator
         ),
         aperture_properties.ExclusiveSphereProperties(
-            cellgrid, 3000.0, recently_heated_gas_filter
+            cellgrid, 3000.0, recently_heated_gas_filter, stellar_age_calculator
         ),
     ]
 

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -137,18 +137,22 @@ def compute_halo_properties():
     stellar_age_calculator = StellarAgeCalculator(cellgrid)
 
     # Get the full list of property calculations we can do
+    # Note that the order matters: we need to do the FOFSubhaloProperties first,
+    # since quantities are filtered based on the particle numbers in there
+    # Similarly, SO 5xR500_crit can only be done after SO 500_crit for obvious
+    # reasons
     halo_prop_list = [
         subhalo_properties.SubhaloProperties(
             cellgrid,
             recently_heated_gas_filter,
             stellar_age_calculator,
-            bound_only=True,
+            bound_only=False,
         ),
         subhalo_properties.SubhaloProperties(
             cellgrid,
             recently_heated_gas_filter,
             stellar_age_calculator,
-            bound_only=False,
+            bound_only=True,
         ),
         SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 200.0, "mean"),
         SO_properties.SOProperties(cellgrid, recently_heated_gas_filter, 50.0, "crit"),

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -137,7 +137,7 @@ def compute_halo_properties():
     )
     stellar_age_calculator = StellarAgeCalculator(cellgrid)
     category_filter = CategoryFilter(
-        Ngeneral=100, Ngas=50, Ndm=100, Nstar=50, Nbaryon=100
+        Ngeneral=100, Ngas=50, Ndm=100, Nstar=50, Nbaryon=100, args.dmo
     )
 
     # Get the full list of property calculations we can do

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -71,6 +71,9 @@ Bryan \& Norman (1998), and \verb+YxR_XXX_ZZZ+ for multiples of some other radiu
 The latter can only be computed after the corresponding density multiple SO radius has been computed. This is 
 achieved by ordering the calculations.
 
+\paragraph{Some properties are directly copied from the original VR catalogue.} These are stored in a
+separate group, \verb+VR+.
+
 \paragraph{The table below summarises} the different halo types.
 
 \begin{longtable}{llcp{6cm}}
@@ -80,6 +83,7 @@ ES & \verb+ExclusiveSphere/XXXkpc+ & \ding{53} & 30, 50, 100, 300, 500, 1000, 30
 IS & \verb+InclusiveSphere/XXXkpc+ & \ding{51} & 30, 50, 100, 300, 500, 1000, 3000 kpc \\
 EP & \verb+ProjectedAperture/XXXkpc/projP+ & \ding{53} & 10, 30, 50, 100 kpc \\
 SO & \verb+SO/XXX+ & \ding{51} & 200 mean, (50, 100, 200, 500, 1000, 2500) crit, 5$\times{}$500 crit \\
+- & \verb+VR/+ & - & Directly copied from VR output \\
 \end{longtable}
 
 \section{Property categories}
@@ -141,7 +145,9 @@ The table below lists all the properties that are computed by SOAP. This table i
 SOAP from the source code, so that all names, types, units, categories and descriptions match what is actually 
 used and output by SOAP. For each quantity, the table indicates for which halo types the property is computed. 
 Superscript numbers refer to more detailed explanations for some of the properties and match the numbers in 
-the next section.
+the next section. The properties at the end of the table that are categorised as `VR' correspond to properties 
+that are directly copied from the VR catalogue and are only listed for completeness. These do not belong to 
+any type.
 
 \input{table}
 

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -7,6 +7,7 @@
 \usepackage{pifont}
 \usepackage{pdflscape}
 \usepackage{graphicx}
+\usepackage{xcolor}
 
 \title{SOAP -- Spherical Overdensity and Aperture Processor}
 \author{Bert Vandenbroucke, Joop Schaye, John Helly, Matthieu Schaller}
@@ -147,7 +148,7 @@ used and output by SOAP. For each quantity, the table indicates for which halo t
 Superscript numbers refer to more detailed explanations for some of the properties and match the numbers in 
 the next section. The properties at the end of the table that are categorised as `VR' correspond to properties 
 that are directly copied from the VR catalogue and are only listed for completeness. These do not belong to 
-any type.
+any type. Properties colored violet are also computed when SOAP is run in dark matter only (DMO) mode.
 
 \input{table}
 

--- a/dummy_halo_generator.py
+++ b/dummy_halo_generator.py
@@ -429,6 +429,12 @@ class DummyHaloGenerator:
         Nstar = int(star_mask.sum())
         if Nstar > 0:
             data["PartType4"] = {}
+            data["PartType4"]["BirthScaleFactors"] = unyt.unyt_array(
+                1.0 / 1.1 + 0.01 * np.random.random(Nstar),
+                dtype=np.float32,
+                units=unyt.dimensionless,
+                registry=reg,
+            )
             data["PartType4"]["Coordinates"] = coords[star_mask]
             data["PartType4"]["GroupNr_all"] = groupnr_all[star_mask]
             data["PartType4"]["GroupNr_bound"] = groupnr_bound[star_mask]

--- a/dummy_halo_generator.py
+++ b/dummy_halo_generator.py
@@ -555,4 +555,11 @@ class DummyHaloGenerator:
 
         Mtot += nu_density * 4.0 * np.pi / 3.0 * rmax**3
 
-        return input_halo, data, rmax, Mtot, npart
+        particle_numbers = {
+            "PartType0": Ngas,
+            "PartType1": Ndm,
+            "PartType4": Nstar,
+            "PartType5": Nbh,
+        }
+
+        return input_halo, data, rmax, Mtot, npart, particle_numbers

--- a/halo_centres.py
+++ b/halo_centres.py
@@ -85,6 +85,7 @@ class SOCatalogue:
                 group_filenames = vr_basename_groups+".%(file_nr)d"
         else:
             group_filenames = None
+        group_filenames = comm.bcast(group_filenames)
         mf = phdf5.MultiFile(group_filenames, file_nr_dataset="Num_of_files")
         local_halo.update(mf.read(["Parent_halo_ID"]))
 

--- a/halo_tasks.py
+++ b/halo_tasks.py
@@ -10,24 +10,33 @@ from halo_properties import ReadRadiusTooSmallError
 import shared_array
 import result_set
 import halo_properties
+from property_table import PropertyTable
 
 # Factor by which to increase search radius when looking for density threshold
-SEARCH_RADIUS_FACTOR=1.2
+SEARCH_RADIUS_FACTOR = 1.2
 
 # Factor by which to increase the region read in around a halo if too small
-READ_RADIUS_FACTOR=1.5
+READ_RADIUS_FACTOR = 1.5
 
 # Radius in Mpc at which we report halos which have a large search radius
-REPORT_RADIUS=20.0
+REPORT_RADIUS = 20.0
 
 
-def process_single_halo(mesh, unit_registry, data, halo_prop_list,
-                        critical_density, mean_density, boxsize, input_halo,
-                        target_density):
+def process_single_halo(
+    mesh,
+    unit_registry,
+    data,
+    halo_prop_list,
+    critical_density,
+    mean_density,
+    boxsize,
+    input_halo,
+    target_density,
+):
     """
     This computes properties for one halo and runs on a single
     MPI rank. Result is a dict of properties of the form
-    
+
     halo_result[property_name] = (unyt_array, description)
 
     where the property_name will be used as the HDF5 dataset name
@@ -45,9 +54,9 @@ def process_single_halo(mesh, unit_registry, data, halo_prop_list,
     Returns None if we need to try again with a larger region.
     """
 
-    swift_mpc   = unyt.Unit("swift_mpc", registry=unit_registry)    
+    swift_mpc = unyt.Unit("swift_mpc", registry=unit_registry)
     snap_length = unyt.Unit("snap_length", registry=unit_registry)
-    snap_mass   = unyt.Unit("snap_mass", registry=unit_registry)
+    snap_mass = unyt.Unit("snap_mass", registry=unit_registry)
     snap_density = snap_mass / (snap_length**3)
 
     # Record which calculations are still to do for this halo
@@ -59,10 +68,10 @@ def process_single_halo(mesh, unit_registry, data, halo_prop_list,
     # Loop until we fall below the required density
     current_radius = input_halo["search_radius"]
     while True:
-        
+
         # Sanity checks on the radius
         assert current_radius <= input_halo["read_radius"]
-        if current_radius > REPORT_RADIUS*swift_mpc:
+        if current_radius > REPORT_RADIUS * swift_mpc:
             print("Halo ID={input_halo['ID']} has large search radius {current_radius}")
 
         # Find the mass within the search radius
@@ -70,16 +79,20 @@ def process_single_halo(mesh, unit_registry, data, halo_prop_list,
         idx = {}
         for ptype in data:
             pos = data[ptype]["Coordinates"]
-            idx[ptype] = mesh[ptype].query_radius_periodic(input_halo["cofp"], current_radius, pos, boxsize)
+            idx[ptype] = mesh[ptype].query_radius_periodic(
+                input_halo["cofp"], current_radius, pos, boxsize
+            )
             if ptype in ptypes_for_so_masses:
                 mass = data[ptype][mass_dataset(ptype)]
                 mass_total += np.sum(mass.full[idx[ptype]], dtype=float)
 
         # Find mean density in the search radius
-        density = mass_total / (4./3.*np.pi*current_radius**3)
+        density = mass_total / (4.0 / 3.0 * np.pi * current_radius**3)
 
         # If we've reached the target density, we can try to compute halo properties
-        max_physical_radius_mpc = 0.0 # Will store the largest physical radius requested by any calculation
+        max_physical_radius_mpc = (
+            0.0  # Will store the largest physical radius requested by any calculation
+        )
         if target_density is None or density <= target_density:
 
             # Extract particles in this halo
@@ -87,14 +100,14 @@ def process_single_halo(mesh, unit_registry, data, halo_prop_list,
             for ptype in data:
                 particle_data[ptype] = {}
                 for name in data[ptype]:
-                    particle_data[ptype][name] = data[ptype][name].full[idx[ptype],...]
+                    particle_data[ptype][name] = data[ptype][name].full[idx[ptype], ...]
 
             # Wrap coordinates to copy closest to the halo centre
             for ptype in particle_data:
                 pos = particle_data[ptype]["Coordinates"]
                 # Shift halo to box centre, wrap all particles into box, shift halo back
-                offset = input_halo["cofp"] - 0.5*boxsize
-                pos[:,:] = ((pos - offset) % boxsize) + offset
+                offset = input_halo["cofp"] - 0.5 * boxsize
+                pos[:, :] = ((pos - offset) % boxsize) + offset
 
             # Try to compute properties of this halo which haven't been done yet
             for prop_nr, halo_prop in enumerate(halo_prop_list):
@@ -102,10 +115,14 @@ def process_single_halo(mesh, unit_registry, data, halo_prop_list,
                     # Already have the result for this one
                     continue
                 try:
-                    halo_prop.calculate(input_halo, current_radius, particle_data, halo_result)
+                    halo_prop.calculate(
+                        input_halo, current_radius, particle_data, halo_result
+                    )
                 except ReadRadiusTooSmallError:
                     # Search radius was too small, so will need to try again with a larger radius.
-                    max_physical_radius_mpc = max(max_physical_radius_mpc, halo_prop.physical_radius_mpc)
+                    max_physical_radius_mpc = max(
+                        max_physical_radius_mpc, halo_prop.physical_radius_mpc
+                    )
                     break
                 else:
                     # The property calculation worked!
@@ -117,7 +134,7 @@ def process_single_halo(mesh, unit_registry, data, halo_prop_list,
 
         # Either the density is still too high or the property calculation failed.
         search_radius = input_halo["search_radius"]
-        required_radius = (max_physical_radius_mpc*swift_mpc).to(search_radius.units)
+        required_radius = (max_physical_radius_mpc * swift_mpc).to(search_radius.units)
         if required_radius > input_halo["read_radius"]:
             # A calculation has set its physical_radius_mpc larger than the region
             # which we read in, so we can't process the halo on this iteration regardless
@@ -131,30 +148,51 @@ def process_single_halo(mesh, unit_registry, data, halo_prop_list,
             return None
         else:
             # We still have a large enough region in memory that we can try a larger radius
-            current_radius = min(current_radius*SEARCH_RADIUS_FACTOR, input_halo["read_radius"])
+            current_radius = min(
+                current_radius * SEARCH_RADIUS_FACTOR, input_halo["read_radius"]
+            )
             current_radius = max(current_radius, required_radius)
 
     # In case we're not doing any calculations with a target density
     if target_density is None:
-        target_density = density*0.0
+        target_density = density * 0.0
 
     # Add the halo index to the result set
-    halo_result["VR/position"]      = (input_halo["cofp"], "Centre of potential of the halo in the input catalogue")
-    halo_result["VR/index"]         = (input_halo["index"],         "Index of this halo in the input catalogue")
-    halo_result["VR/ID"]            = (input_halo["ID"],            "VELOCIraptor halo ID")
-    halo_result["VR/Structuretype"] = (input_halo["Structuretype"], "VELOCIraptor Structuretype parameter")
+    for vrkey in PropertyTable.vr_properties:
+        vrprops = PropertyTable.full_property_list[f"VR{vrkey}"]
+        vrname = vrprops[0]
+        vrdescription = vrprops[4]
+        halo_result[f"VR/{vrname}"] = (input_halo[vrkey], vrdescription)
 
     # Store search radius and density within that radius
-    halo_result["SearchRadius/search_radius"]            = (current_radius,                  "Search radius for property calculation")
-    halo_result["SearchRadius/density_in_search_radius"] = (density.to(snap_density),        "Density within the search radius")
-    halo_result["SearchRadius/target_density"]           = (target_density.to(snap_density), "Target density for property calculation")
+    halo_result["SearchRadius/search_radius"] = (
+        current_radius,
+        "Search radius for property calculation",
+    )
+    halo_result["SearchRadius/density_in_search_radius"] = (
+        density.to(snap_density),
+        "Density within the search radius",
+    )
+    halo_result["SearchRadius/target_density"] = (
+        target_density.to(snap_density),
+        "Target density for property calculation",
+    )
 
     return halo_result
 
 
-def process_halos(comm, unit_registry, data, mesh, halo_prop_list,
-                  critical_density, mean_density, boxsize, halo_arrays,
-                  results):
+def process_halos(
+    comm,
+    unit_registry,
+    data,
+    mesh,
+    halo_prop_list,
+    critical_density,
+    mean_density,
+    boxsize,
+    halo_arrays,
+    results,
+):
     """
     This uses all of the MPI ranks on one compute node to compute halo properties
     for a single "chunk" of the simulation.
@@ -162,7 +200,7 @@ def process_halos(comm, unit_registry, data, mesh, halo_prop_list,
     Each rank returns a dict with the properties of the halos it processed.
     The dict keys are the property names. The values are tuples containing
     (unyt_array, description).
-    
+
     Halos where done=1 are not processed and don't generate an entry in the
     output arrays.
 
@@ -177,12 +215,12 @@ def process_halos(comm, unit_registry, data, mesh, halo_prop_list,
     for halo_prop in halo_prop_list:
         # Ensure target density is no greater than mean density multiple
         if halo_prop.mean_density_multiple is not None:
-            density = halo_prop.mean_density_multiple*mean_density
+            density = halo_prop.mean_density_multiple * mean_density
             if target_density is None or density < target_density:
                 target_density = density
         # Ensure target density is no greater than critical density multiple
         if halo_prop.critical_density_multiple is not None:
-            density = halo_prop.critical_density_multiple*critical_density
+            density = halo_prop.critical_density_multiple * critical_density
             if target_density is None or density < target_density:
                 target_density = density
 
@@ -201,7 +239,7 @@ def process_halos(comm, unit_registry, data, mesh, halo_prop_list,
     t0_all = time.time()
 
     # Count halos to do
-    nr_halos_left = comm.allreduce(np.sum(halo_arrays["done"].local==0))
+    nr_halos_left = comm.allreduce(np.sum(halo_arrays["done"].local == 0))
 
     # Loop until all halos are done
     nr_halos = len(halo_arrays["index"].full)
@@ -229,12 +267,20 @@ def process_halos(comm, unit_registry, data, mesh, halo_prop_list,
                 # Extract this halo's VR information (centre, radius, index etc)
                 input_halo = {}
                 for name in halo_arrays:
-                    input_halo[name] = halo_arrays[name].full[task_to_do,...].copy()
+                    input_halo[name] = halo_arrays[name].full[task_to_do, ...].copy()
 
                 # Fetch the results for this particular halo
-                halo_result = process_single_halo(mesh, unit_registry, data, halo_prop_list,
-                                                  critical_density, mean_density,
-                                                  boxsize, input_halo, target_density)
+                halo_result = process_single_halo(
+                    mesh,
+                    unit_registry,
+                    data,
+                    halo_prop_list,
+                    critical_density,
+                    mean_density,
+                    boxsize,
+                    input_halo,
+                    target_density,
+                )
                 if halo_result is not None:
                     # Store results and flag this halo as done
                     results.append(halo_result)
@@ -244,15 +290,19 @@ def process_halos(comm, unit_registry, data, mesh, halo_prop_list,
                     # We didn't read in a large enough region. Update the shared radius
                     # arrays so that we read a larger region next time and start the
                     # search from whatever radius we had reached this time.
-                    new_read_radius = max(input_halo["read_radius"] * READ_RADIUS_FACTOR,
-                                          input_halo["search_radius"])
+                    new_read_radius = max(
+                        input_halo["read_radius"] * READ_RADIUS_FACTOR,
+                        input_halo["search_radius"],
+                    )
                     # Set the radius around the halo to read in
                     halo_arrays["read_radius"].full[task_to_do] = new_read_radius
                     # Set the initial guess at the radius we need
-                    halo_arrays["search_radius"].full[task_to_do] = input_halo["search_radius"]
+                    halo_arrays["search_radius"].full[task_to_do] = input_halo[
+                        "search_radius"
+                    ]
 
             t1_task = time.time()
-            task_time += (t1_task-t0_task)
+            task_time += t1_task - t0_task
         else:
             # We ran out of halos to do
             break
@@ -262,10 +312,10 @@ def process_halos(comm, unit_registry, data, mesh, halo_prop_list,
 
     # Count halos left to do
     comm.barrier()
-    nr_halos_left = comm.allreduce(np.sum(halo_arrays["done"].local==0))
+    nr_halos_left = comm.allreduce(np.sum(halo_arrays["done"].local == 0))
 
     # Stop the clock
     comm.barrier()
     t1_all = time.time()
-    
-    return t1_all-t0_all, task_time, nr_halos_left, comm.allreduce(nr_done_this_rank)
+
+    return t1_all - t0_all, task_time, nr_halos_left, comm.allreduce(nr_done_this_rank)

--- a/lazy_properties.py
+++ b/lazy_properties.py
@@ -1,0 +1,21 @@
+#!/bin/env python
+
+
+def lazy_property(fn):
+    """
+    Decorator for class methods to turn them into lazily evaluated properties.
+
+    Decorating a function with @lazy_property is practically the same as
+    decorating it with @property, except that the function is only evaluated
+    once, and only when it is actually used.
+    """
+
+    attr_name = "_lazy_" + fn.__name__
+
+    @property
+    def _lazy_property(self):
+        if not hasattr(self, attr_name):
+            setattr(self, attr_name, fn(self))
+        return getattr(self, attr_name)
+
+    return _lazy_property

--- a/projected_aperture_properties.py
+++ b/projected_aperture_properties.py
@@ -168,7 +168,7 @@ class ProjectedApertureProperties(HaloProperty):
             # all variables are defined with physical units and an appropriate dtype
             # we need to use the custom unit registry so that everything can be converted
             # back to snapshot units in the end
-            for name, _, shape, dtype, unit, _, _ in self.property_list:
+            for name, _, shape, dtype, unit, _, _, _ in self.property_list:
                 if shape > 1:
                     val = [0] * shape
                 else:
@@ -358,7 +358,7 @@ class ProjectedApertureProperties(HaloProperty):
             prefix = (
                 f"ProjectedAperture/{self.physical_radius_mpc*1000.:.0f}kpc/{projname}"
             )
-            for name, outputname, _, _, _, description, _ in self.property_list:
+            for name, outputname, _, _, _, description, _, _ in self.property_list:
                 halo_result.update(
                     {f"{prefix}/{outputname}": (projected_aperture[name], description)}
                 )
@@ -418,6 +418,7 @@ def test_projected_aperture_properties():
                 size,
                 dtype,
                 unit_string,
+                _,
                 _,
                 _,
             ) in property_calculator.property_list:

--- a/projected_aperture_properties.py
+++ b/projected_aperture_properties.py
@@ -339,6 +339,8 @@ class SingleProjectionProjectedApertureParticleData:
 
     @lazy_property
     def ProjectedGasAxisLengths(self):
+        if self.Mgas == 0:
+            return None
         return get_projected_axis_lengths(
             self.proj_mass_gas, self.proj_pos_gas, self.iproj
         )
@@ -373,12 +375,16 @@ class SingleProjectionProjectedApertureParticleData:
 
     @lazy_property
     def ProjectedStellarAxisLengths(self):
+        if self.Mstar == 0:
+            return None
         return get_projected_axis_lengths(
             self.proj_mass_star, self.proj_pos_star, self.iproj
         )
 
     @lazy_property
     def ProjectedBaryonAxisLengths(self):
+        if self.Mbaryons == 0:
+            return None
         return get_projected_axis_lengths(
             self.proj_mass_baryons, self.proj_pos_baryons, self.iproj
         )

--- a/projected_aperture_properties.py
+++ b/projected_aperture_properties.py
@@ -560,7 +560,12 @@ class ProjectedApertureProperties(HaloProperty):
             # all variables are defined with physical units and an appropriate dtype
             # we need to use the custom unit registry so that everything can be converted
             # back to snapshot units in the end
-            for name, _, shape, dtype, unit, _, category, _ in self.property_list:
+            for prop in self.property_list:
+                name = prop[0]
+                shape = prop[2]
+                dtype = prop[3]
+                unit = prop[4]
+                category = prop[6]
                 if shape > 1:
                     val = [0] * shape
                 else:
@@ -584,7 +589,10 @@ class ProjectedApertureProperties(HaloProperty):
             prefix = (
                 f"ProjectedAperture/{self.physical_radius_mpc*1000.:.0f}kpc/{projname}"
             )
-            for name, outputname, _, _, _, description, _, _ in self.property_list:
+            for prop in self.property_list:
+                name = prop[0]
+                outputname = prop[1]
+                description = prop[5]
                 halo_result.update(
                     {f"{prefix}/{outputname}": (projected_aperture[name], description)}
                 )
@@ -666,16 +674,11 @@ def test_projected_aperture_properties():
         assert input_data == input_data_copy
 
         for proj in ["projx", "projy", "projz"]:
-            for (
-                _,
-                outputname,
-                size,
-                dtype,
-                unit_string,
-                _,
-                _,
-                _,
-            ) in property_calculator.property_list:
+            for prop in property_calculator.property_list:
+                outputname = prop[1]
+                size = prop[2]
+                dtype = prop[3]
+                unit_string = prop[4]
                 full_name = f"ProjectedAperture/30kpc/{proj}/{outputname}"
                 assert full_name in halo_result
                 result = halo_result[full_name][0]

--- a/projected_aperture_properties.py
+++ b/projected_aperture_properties.py
@@ -561,6 +561,10 @@ class ProjectedApertureProperties(HaloProperty):
             # we need to use the custom unit registry so that everything can be converted
             # back to snapshot units in the end
             for prop in self.property_list:
+                # skip non-DMO properties in DMO run mode
+                is_dmo = prop[8]
+                if do_calculation["DMO"] and not is_dmo:
+                    continue
                 name = prop[0]
                 shape = prop[2]
                 dtype = prop[3]
@@ -590,6 +594,10 @@ class ProjectedApertureProperties(HaloProperty):
                 f"ProjectedAperture/{self.physical_radius_mpc*1000.:.0f}kpc/{projname}"
             )
             for prop in self.property_list:
+                # skip non-DMO properties in DMO run mode
+                is_dmo = prop[8]
+                if do_calculation["DMO"] and not is_dmo:
+                    continue
                 name = prop[0]
                 outputname = prop[1]
                 description = prop[5]

--- a/projected_aperture_properties.py
+++ b/projected_aperture_properties.py
@@ -392,7 +392,7 @@ def test_projected_aperture_properties():
     property_calculator = DummyProjectedApertureProperties()
 
     for i in range(100):
-        input_halo, data, _, _, _ = dummy_halos.get_random_halo(
+        input_halo, data, _, _, _, _ = dummy_halos.get_random_halo(
             [1, 10, 100, 1000, 10000]
         )
 

--- a/property_table.py
+++ b/property_table.py
@@ -726,6 +726,22 @@ class PropertyTable:
             "Mass-weighted velocity dispersion of the stars. Measured relative to the stellar centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
             "star",
         ),
+        "stellar_age_mw": (
+            "MassWeightedMeanStellarAge",
+            1,
+            np.float32,
+            "Myr",
+            "Mass weighted mean stellar age.",
+            "star",
+        ),
+        "stellar_age_lw": (
+            "LuminosityWeightedMeanStellarAge",
+            1,
+            np.float32,
+            "Myr",
+            "Luminosity weighted mean stellar age. The weight is the r band luminosity.",
+            "star",
+        ),
     }
 
     def get_footnotes(self, name):

--- a/property_table.py
+++ b/property_table.py
@@ -73,12 +73,16 @@ class PropertyTable:
     }
 
     # List of properties that get computed
+    # The key for each property is the name that is used internally in SOAP
     # For each property, we have the following columns:
-    #  - name: Name of the property within calculate() and in the output file
+    #  - name: Name of the property within the output file
     #  - shape: Shape of this property for a single halo (1: scalar, 3: vector...)
     #  - dtype: Data type that will be used. Should have enough precision to avoid over/underflow
     #  - unit: Units that will be used internally and for the output.
     #  - description: Description string that will be used to describe the property in the output.
+    #  - category: Category used to decide if this property should be calculated for a halo
+    #  - lossy compression filter: Lossy compression filter used in the output to reduce the file size
+    #  - DMO property: Should this property be calculated for a DMO run?
     full_property_list = {
         "BHlasteventa": (
             "BlackHolesLastEventScalefactor",
@@ -88,6 +92,7 @@ class PropertyTable:
             "Scale-factor of last AGN event.",
             "general",
             "FMantissa9",
+            False,
         ),
         "BHmaxAR": (
             "MostMassiveBlackHoleAccretionRate",
@@ -97,6 +102,7 @@ class PropertyTable:
             "Gas accretion rate of most massive black hole.",
             "general",
             "FMantissa9",
+            False,
         ),
         "BHmaxID": (
             "MostMassiveBlackHoleID",
@@ -106,6 +112,7 @@ class PropertyTable:
             "ID of most massive black hole.",
             "basic",
             "Nbit40",
+            False,
         ),
         "BHmaxM": (
             "MostMassiveBlackHoleMass",
@@ -115,6 +122,7 @@ class PropertyTable:
             "Mass of most massive black hole.",
             "basic",
             "FMantissa9",
+            False,
         ),
         "BHmaxlasteventa": (
             "MostMassiveBlackHoleLastEventScalefactor",
@@ -124,6 +132,7 @@ class PropertyTable:
             "Scale-factor of last AGN event for most massive black hole.",
             "general",
             "FMantissa9",
+            False,
         ),
         "BHmaxpos": (
             "MostMassiveBlackHolePosition",
@@ -133,6 +142,7 @@ class PropertyTable:
             "Position of most massive black hole.",
             "general",
             "FMantissa9",
+            False,
         ),
         "BHmaxvel": (
             "MostMassiveBlackHoleVelocity",
@@ -142,6 +152,7 @@ class PropertyTable:
             "Velocity of most massive black hole relative to the simulation volume.",
             "general",
             "FMantissa9",
+            False,
         ),
         "BaryonAxisLengths": (
             "BaryonAxisLengths",
@@ -151,6 +162,7 @@ class PropertyTable:
             "Axis lengths of the baryonic (gas and stars) mass distribution, computed from the 3D baryon inertia tensor, relative to the centre of potential.",
             "baryon",
             "FMantissa9",
+            False,
         ),
         "DMAxisLengths": (
             "DarkMatterAxisLengths",
@@ -160,6 +172,7 @@ class PropertyTable:
             "Axis lengths of the dark matter mass distribution, computed from the 3D DM inertia tensor, relative to the centre of potential.",
             "dm",
             "FMantissa9",
+            True,
         ),
         "DopplerB": (
             "DopplerB",
@@ -169,6 +182,7 @@ class PropertyTable:
             "Kinetic Sunyaey-Zel'dovich effect, assuming a line of sight towards the position of the first lightcone observer.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "DtoTgas": (
             "DiscToTotalGasMassFraction",
@@ -178,6 +192,7 @@ class PropertyTable:
             "Fraction of the total gas mass that is co-rotating.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "DtoTstar": (
             "DiscToTotalStellarMassFraction",
@@ -187,6 +202,7 @@ class PropertyTable:
             "Fraction of the total stellar mass that is co-rotating.",
             "star",
             "FMantissa9",
+            False,
         ),
         "Ekin_gas": (
             "KineticEnergyGas",
@@ -196,6 +212,7 @@ class PropertyTable:
             "Total kinetic energy of the gas, relative to the gas centre of mass velocity.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Ekin_star": (
             "KineticEnergyStars",
@@ -205,6 +222,7 @@ class PropertyTable:
             "Total kinetic energy of the stars, relative to the stellar centre of mass velocity.",
             "star",
             "FMantissa9",
+            False,
         ),
         "Etherm_gas": (
             "ThermalEnergyGas",
@@ -214,6 +232,7 @@ class PropertyTable:
             "Total thermal energy of the gas.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "GasAxisLengths": (
             "GasAxisLengths",
@@ -223,6 +242,7 @@ class PropertyTable:
             "Axis lengths of the gas mass distribution, computed from the 3D gas inertia tensor, relative to the centre of potential.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "HalfMassRadiusBaryon": (
             "HalfMassRadiusBaryons",
@@ -232,6 +252,7 @@ class PropertyTable:
             "Baryonic (gas and stars) half mass radius.",
             "baryon",
             "FMantissa9",
+            False,
         ),
         "HalfMassRadiusDM": (
             "HalfMassRadiusDarkMatter",
@@ -241,6 +262,7 @@ class PropertyTable:
             "Dark matter half mass radius.",
             "dm",
             "FMantissa9",
+            True,
         ),
         "HalfMassRadiusGas": (
             "HalfMassRadiusGas",
@@ -250,6 +272,7 @@ class PropertyTable:
             "Gas half mass radius.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "HalfMassRadiusStar": (
             "HalfMassRadiusStars",
@@ -259,6 +282,7 @@ class PropertyTable:
             "Stellar half mass radius.",
             "star",
             "FMantissa9",
+            False,
         ),
         "HalfMassRadiusTot": (
             "HalfMassRadiusTotal",
@@ -268,6 +292,7 @@ class PropertyTable:
             "Total half mass radius.",
             "general",
             "FMantissa9",
+            True,
         ),
         "Lbaryons": (
             "AngularMomentumBaryons",
@@ -277,6 +302,7 @@ class PropertyTable:
             "Total angular momentum of baryons (gas and stars), relative to the centre of potential and baryonic centre of mass velocity.",
             "baryon",
             "FMantissa9",
+            False,
         ),
         "Ldm": (
             "AngularMomentumDarkMatter",
@@ -286,6 +312,7 @@ class PropertyTable:
             "Total angular momentum of the dark matter, relative to the centre of potential and DM centre of mass velocity.",
             "dm",
             "FMantissa9",
+            True,
         ),
         "Lgas": (
             "AngularMomentumGas",
@@ -295,6 +322,7 @@ class PropertyTable:
             "Total angular momentum of the gas, relative to the centre of potential and gas centre of mass velocity.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Lstar": (
             "AngularMomentumStars",
@@ -304,6 +332,7 @@ class PropertyTable:
             "Total angular momentum of the stars, relative to the centre of potential and stellar centre of mass velocity.",
             "star",
             "FMantissa9",
+            False,
         ),
         "Mbh_dynamical": (
             "BlackHolesDynamicalMass",
@@ -313,6 +342,7 @@ class PropertyTable:
             "Total BH dynamical mass.",
             "basic",
             "FMantissa9",
+            False,
         ),
         "Mbh_subgrid": (
             "BlackHolesSubgridMass",
@@ -322,6 +352,7 @@ class PropertyTable:
             "Total BH subgrid mass.",
             "basic",
             "FMantissa9",
+            False,
         ),
         "Mdm": (
             "DarkMatterMass",
@@ -331,6 +362,7 @@ class PropertyTable:
             "Total DM mass.",
             "basic",
             "FMantissa9",
+            True,
         ),
         "Mfrac_satellites": (
             "MassFractionSatellites",
@@ -340,6 +372,7 @@ class PropertyTable:
             "Fraction of mass that is bound to a satellite.",
             "general",
             "FMantissa9",
+            True,
         ),
         "Mgas": (
             "GasMass",
@@ -349,6 +382,7 @@ class PropertyTable:
             "Total gas mass.",
             "basic",
             "FMantissa9",
+            False,
         ),
         "MgasFe": (
             "GasMassInIron",
@@ -358,6 +392,7 @@ class PropertyTable:
             "Total gas mass in iron.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "MgasFe_SF": (
             "StarFormingGasMassInIron",
@@ -367,6 +402,7 @@ class PropertyTable:
             "Total gas mass in iron for gas that is star-forming.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "MgasO": (
             "GasMassInOxygen",
@@ -376,6 +412,7 @@ class PropertyTable:
             "Total gas mass in oxygen.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "MgasO_SF": (
             "StarFormingGasMassInOxygen",
@@ -385,6 +422,7 @@ class PropertyTable:
             "Total gas mass in oxygen for gas that is star-forming.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Mgas_SF": (
             "StarFormingGasMass",
@@ -394,6 +432,7 @@ class PropertyTable:
             "Total mass of star-forming gas.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Mgasmetal": (
             "GasMassInMetals",
@@ -403,6 +442,7 @@ class PropertyTable:
             "Total gas mass in metals.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Mgasmetal_SF": (
             "StarFormingGasMassInMetals",
@@ -412,6 +452,7 @@ class PropertyTable:
             "Total gas mass in metals for gas that is star-forming.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Mhotgas": (
             "HotGasMass",
@@ -421,6 +462,7 @@ class PropertyTable:
             "Total mass of gas with a temperature above 1e5 K.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Mnu": (
             "RawNeutrinoMass",
@@ -430,6 +472,7 @@ class PropertyTable:
             "Total neutrino particle mass.",
             "basic",
             "FMantissa9",
+            True,
         ),
         "MnuNS": (
             "NoiseSuppressedNeutrinoMass",
@@ -439,6 +482,7 @@ class PropertyTable:
             "Noise suppressed total neutrino mass.",
             "basic",
             "FMantissa9",
+            True,
         ),
         "Mstar": (
             "StellarMass",
@@ -448,6 +492,7 @@ class PropertyTable:
             "Total stellar mass.",
             "basic",
             "FMantissa9",
+            False,
         ),
         "MstarFe": (
             "StellarMassInIron",
@@ -457,6 +502,7 @@ class PropertyTable:
             "Total stellar mass in iron.",
             "star",
             "FMantissa9",
+            False,
         ),
         "MstarO": (
             "StellarMassInOxygen",
@@ -466,6 +512,7 @@ class PropertyTable:
             "Total stellar mass in oxygen.",
             "star",
             "FMantissa9",
+            False,
         ),
         "Mstar_init": (
             "StellarInitialMass",
@@ -475,6 +522,7 @@ class PropertyTable:
             "Total stellar initial mass.",
             "star",
             "FMantissa9",
+            False,
         ),
         "Mstarmetal": (
             "StellarMassInMetals",
@@ -484,6 +532,7 @@ class PropertyTable:
             "Total stellar mass in metals.",
             "star",
             "FMantissa9",
+            False,
         ),
         "Mtot": (
             "TotalMass",
@@ -493,6 +542,7 @@ class PropertyTable:
             "Total mass.",
             "basic",
             "FMantissa9",
+            True,
         ),
         "Nbh": (
             "NumberOfBlackHoleParticles",
@@ -502,6 +552,7 @@ class PropertyTable:
             "Number of black hole particles.",
             "basic",
             "None",
+            False,
         ),
         "Ndm": (
             "NumberOfDarkMatterParticles",
@@ -511,6 +562,7 @@ class PropertyTable:
             "Number of dark matter particles.",
             "basic",
             "None",
+            True,
         ),
         "Ngas": (
             "NumberOfGasParticles",
@@ -520,6 +572,7 @@ class PropertyTable:
             "Number of gas particles.",
             "basic",
             "None",
+            False,
         ),
         "Nnu": (
             "NumberOfNeutrinoParticles",
@@ -529,6 +582,7 @@ class PropertyTable:
             "Number of neutrino particles.",
             "basic",
             "None",
+            False,
         ),
         "Nstar": (
             "NumberOfStarParticles",
@@ -538,6 +592,7 @@ class PropertyTable:
             "Number of star particles.",
             "basic",
             "None",
+            False,
         ),
         "ProjectedBaryonAxisLengths": (
             "ProjectedBaryonAxisLengths",
@@ -547,6 +602,7 @@ class PropertyTable:
             "Axis lengths of the projected baryon (gas and stars) mass distribution, computed from the 2D baryon inertia tensor, relative to the centre of potential.",
             "baryon",
             "FMantissa9",
+            False,
         ),
         "ProjectedGasAxisLengths": (
             "ProjectedGasAxisLengths",
@@ -556,6 +612,7 @@ class PropertyTable:
             "Axis lengths of the projected gas mass distribution, computed from the 2D gas inertia tensor, relative to the centre of potential.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "ProjectedStellarAxisLengths": (
             "ProjectedStellarAxisLengths",
@@ -565,6 +622,7 @@ class PropertyTable:
             "Axis lengths of the projected stellar mass distribution, computed from the 2D stellar inertia tensor, relative to the centre of potential.",
             "star",
             "FMantissa9",
+            False,
         ),
         "R_vmax": (
             "MaximumCircularVelocityRadius",
@@ -574,6 +632,7 @@ class PropertyTable:
             "Radius at which Vmax is reached.",
             "general",
             "FMantissa9",
+            True,
         ),
         "SFR": (
             "StarFormationRate",
@@ -583,6 +642,7 @@ class PropertyTable:
             "Total star formation rate.",
             "general",
             "FMantissa9",
+            False,
         ),
         "StellarAxisLengths": (
             "StellarAxisLengths",
@@ -592,6 +652,7 @@ class PropertyTable:
             "Axis lengths of the stellar mass distribution, computed from the 3D stellar inertia tensor, relative to the centre of potential.",
             "star",
             "FMantissa9",
+            False,
         ),
         "StellarLuminosity": (
             "StellarLuminosity",
@@ -601,6 +662,7 @@ class PropertyTable:
             "Total stellar luminosity in the 9 GAMA bands.",
             "star",
             "FMantissa9",
+            False,
         ),
         "Tgas": (
             "GasTemperature",
@@ -610,6 +672,7 @@ class PropertyTable:
             "Mass-weighted mean gas temperature.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Tgas_no_agn": (
             "GasTemperatureWithoutRecentAGNHeating",
@@ -619,6 +682,7 @@ class PropertyTable:
             "Mass-weighted mean gas temperature, excluding gas that was recently heated by AGN.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Tgas_no_cool": (
             "GasTemperatureWithoutCoolGas",
@@ -628,6 +692,7 @@ class PropertyTable:
             "Mass-weighted mean gas temperature, excluding cool gas with a temperature below 1e5 K.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "Tgas_no_cool_no_agn": (
             "GasTemperatureWithoutCoolGasAndRecentAGNHeating",
@@ -637,6 +702,7 @@ class PropertyTable:
             "Mass-weighted mean gas temperature, excluding cool gas with a temperature below 1e5 K and gas that was recently heated by AGN.",
             "gas",
             "FMantissa9",
+            False,
         ),
         "TotalAxisLengths": (
             "TotalAxisLengths",
@@ -646,240 +712,7 @@ class PropertyTable:
             "Axis lengths of the total mass distribution, computed from the 3D inertia tensor, relative to the centre of potential.",
             "general",
             "FMantissa9",
-        ),
-        "Vmax": (
-            "MaximumCircularVelocity",
-            1,
-            np.float32,
-            "km/s",
-            "Maximum circular velocity.",
-            "general",
-            "FMantissa9",
-        ),
-        "Xraylum": (
-            "XRayLuminosity",
-            3,
-            np.float64,
-            "erg/s",
-            "Total rest-frame Xray luminosity in three bands.",
-            "gas",
-            "FMantissa9",
-        ),
-        "Xraylum_no_agn": (
-            "XRayLuminosityWithoutRecentAGNHeating",
-            3,
-            np.float64,
-            "erg/s",
-            "Total rest-frame Xray luminosity in three bands. Excludes gas that was recently heated by AGN.",
-            "gas",
-            "FMantissa9",
-        ),
-        "Xrayphlum": (
-            "XRayPhotonLuminosity",
-            3,
-            np.float64,
-            "1/s",
-            "Total rest-frame Xray photon luminosity in three bands.",
-            "gas",
-            "FMantissa9",
-        ),
-        "Xrayphlum_no_agn": (
-            "XRayPhotonLuminosityWithoutRecentAGNHeating",
-            3,
-            np.float64,
-            "1/s",
-            "Total rest-frame Xray photon luminosity in three bands. Exclude gas that was recently heated by AGN.",
-            "gas",
-            "FMantissa9",
-        ),
-        "com": (
-            "CentreOfMass",
-            3,
-            np.float32,
-            "Mpc",
-            "Centre of mass.",
-            "basic",
-            "DScale5",
-        ),
-        "com_gas": (
-            "GasCentreOfMass",
-            3,
-            np.float32,
-            "Mpc",
-            "Centre of mass of gas.",
-            "gas",
-            "DScale5",
-        ),
-        "com_star": (
-            "StellarCentreOfMass",
-            3,
-            np.float32,
-            "Mpc",
-            "Centre of mass of stars.",
-            "star",
-            "DScale5",
-        ),
-        "compY": (
-            "ComptonY",
-            1,
-            np.float64,
-            "cm**2",
-            "Total Compton y parameter.",
-            "gas",
-            "FMantissa9",
-        ),
-        "compY_no_agn": (
-            "ComptonYWithoutRecentAGNHeating",
-            1,
-            np.float64,
-            "cm**2",
-            "Total Compton y parameter. Excludes gas that was recently heated by AGN.",
-            "gas",
-            "FMantissa9",
-        ),
-        "kappa_corot_baryons": (
-            "KappaCorotBaryons",
-            1,
-            np.float32,
-            "dimensionless",
-            "Kappa-corot for baryons (gas and stars), relative to the centre of potential and the centre of mass velocity of the baryons.",
-            "baryon",
-            "FMantissa9",
-        ),
-        "kappa_corot_gas": (
-            "KappaCorotGas",
-            1,
-            np.float32,
-            "dimensionless",
-            "Kappa-corot for gas, relative to the centre of potential and the centre of mass velocity of the gas.",
-            "gas",
-            "FMantissa9",
-        ),
-        "kappa_corot_star": (
-            "KappaCorotStars",
-            1,
-            np.float32,
-            "dimensionless",
-            "Kappa-corot for stars, relative to the centre of potential and the centre of mass velocity of the stars.",
-            "star",
-            "FMantissa9",
-        ),
-        "proj_veldisp_dm": (
-            "DarkMatterProjectedVelocityDispersion",
-            1,
-            np.float32,
-            "km/s",
-            "Mass-weighted velocity dispersion of the DM along the projection axis, relative to the DM centre of mass velocity.",
-            "dm",
-            "FMantissa9",
-        ),
-        "proj_veldisp_gas": (
-            "GasProjectedVelocityDispersion",
-            1,
-            np.float32,
-            "km/s",
-            "Mass-weighted velocity dispersion of the gas along the projection axis, relative to the gas centre of mass velocity.",
-            "gas",
-            "FMantissa9",
-        ),
-        "proj_veldisp_star": (
-            "StellarProjectedVelocityDispersion",
-            1,
-            np.float32,
-            "km/s",
-            "Mass-weighted velocity dispersion of the stars along the projection axis, relative to the stellar centre of mass velocity.",
-            "star",
-            "FMantissa9",
-        ),
-        "r": (
-            "SORadius",
-            1,
-            np.float32,
-            "Mpc",
-            "Radius of a sphere {label}",
-            "basic",
-            "FMantissa9",
-        ),
-        "spin_parameter": (
-            "SpinParameter",
-            1,
-            np.float32,
-            "dimensionless",
-            "Bullock et al. (2001) spin parameter.",
-            "general",
-            "FMantissa9",
-        ),
-        "stellar_age_lw": (
-            "LuminosityWeightedMeanStellarAge",
-            1,
-            np.float32,
-            "Myr",
-            "Luminosity weighted mean stellar age. The weight is the r band luminosity.",
-            "star",
-            "FMantissa9",
-        ),
-        "stellar_age_mw": (
-            "MassWeightedMeanStellarAge",
-            1,
-            np.float32,
-            "Myr",
-            "Mass weighted mean stellar age.",
-            "star",
-            "FMantissa9",
-        ),
-        "vcom": (
-            "CentreOfMassVelocity",
-            3,
-            np.float32,
-            "km/s",
-            "Centre of mass velocity.",
-            "basic",
-            "DScale1",
-        ),
-        "vcom_gas": (
-            "GasCentreOfMassVelocity",
-            3,
-            np.float32,
-            "km/s",
-            "Centre of mass velocity of gas.",
-            "gas",
-            "DScale1",
-        ),
-        "vcom_star": (
-            "StellarCentreOfMassVelocity",
-            3,
-            np.float32,
-            "km/s",
-            "Centre of mass velocity of stars.",
-            "star",
-            "DScale1",
-        ),
-        "veldisp_matrix_dm": (
-            "DarkMatterVelocityDispersionMatrix",
-            6,
-            np.float32,
-            "km**2/s**2",
-            "Mass-weighted velocity dispersion of the dark matter. Measured relative to the DM centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
-            "dm",
-            "FMantissa9",
-        ),
-        "veldisp_matrix_gas": (
-            "GasVelocityDispersionMatrix",
-            6,
-            np.float32,
-            "km**2/s**2",
-            "Mass-weighted velocity dispersion of the gas. Measured relative to the gas centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
-            "gas",
-            "FMantissa9",
-        ),
-        "veldisp_matrix_star": (
-            "StellarVelocityDispersionMatrix",
-            6,
-            np.float32,
-            "km**2/s**2",
-            "Mass-weighted velocity dispersion of the stars. Measured relative to the stellar centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
-            "star",
-            "FMantissa9",
+            True,
         ),
         "VRID": (
             "ID",
@@ -889,24 +722,7 @@ class PropertyTable:
             "ID assigned to this halo by VR.",
             "VR",
             "None",
-        ),
-        "VRindex": (
-            "Index",
-            1,
-            np.int64,
-            "dimensionless",
-            "Index of this halo in the original VR output.",
-            "VR",
-            "None",
-        ),
-        "VRhostHaloID": (
-            "HostHaloID",
-            1,
-            np.int64,
-            "dimensionless",
-            "VR/ID of the top level parent of this halo. -1 for field halos.",
-            "VR",
-            "None",
+            True,
         ),
         "VRParent_halo_ID": (
             "ParentHaloID",
@@ -916,15 +732,7 @@ class PropertyTable:
             "VR/ID of the direct parent of this halo. -1 for field halos.",
             "VR",
             "None",
-        ),
-        "VRnumSubStruct": (
-            "NumberOfSubstructures",
-            1,
-            np.uint64,
-            "dimensionless",
-            "Number of sub-structures within this halo.",
-            "VR",
-            "None",
+            True,
         ),
         "VRStructuretype": (
             "StructureType",
@@ -934,6 +742,7 @@ class PropertyTable:
             "Structure type identified by VR. Field halos are 10, higher numbers are for satellites.",
             "VR",
             "None",
+            True,
         ),
         "VRcofp": (
             "CentreOfPotential",
@@ -943,6 +752,297 @@ class PropertyTable:
             "Centre of potential, as identified by VR. Used as reference for all relative positions.",
             "VR",
             "DScale5",
+            True,
+        ),
+        "VRhostHaloID": (
+            "HostHaloID",
+            1,
+            np.int64,
+            "dimensionless",
+            "VR/ID of the top level parent of this halo. -1 for field halos.",
+            "VR",
+            "None",
+            True,
+        ),
+        "VRindex": (
+            "Index",
+            1,
+            np.int64,
+            "dimensionless",
+            "Index of this halo in the original VR output.",
+            "VR",
+            "None",
+            True,
+        ),
+        "VRnumSubStruct": (
+            "NumberOfSubstructures",
+            1,
+            np.uint64,
+            "dimensionless",
+            "Number of sub-structures within this halo.",
+            "VR",
+            "None",
+            True,
+        ),
+        "Vmax": (
+            "MaximumCircularVelocity",
+            1,
+            np.float32,
+            "km/s",
+            "Maximum circular velocity.",
+            "general",
+            "FMantissa9",
+            True,
+        ),
+        "Xraylum": (
+            "XRayLuminosity",
+            3,
+            np.float64,
+            "erg/s",
+            "Total rest-frame Xray luminosity in three bands.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "Xraylum_no_agn": (
+            "XRayLuminosityWithoutRecentAGNHeating",
+            3,
+            np.float64,
+            "erg/s",
+            "Total rest-frame Xray luminosity in three bands. Excludes gas that was recently heated by AGN.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "Xrayphlum": (
+            "XRayPhotonLuminosity",
+            3,
+            np.float64,
+            "1/s",
+            "Total rest-frame Xray photon luminosity in three bands.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "Xrayphlum_no_agn": (
+            "XRayPhotonLuminosityWithoutRecentAGNHeating",
+            3,
+            np.float64,
+            "1/s",
+            "Total rest-frame Xray photon luminosity in three bands. Exclude gas that was recently heated by AGN.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "com": (
+            "CentreOfMass",
+            3,
+            np.float32,
+            "Mpc",
+            "Centre of mass.",
+            "basic",
+            "DScale5",
+            True,
+        ),
+        "com_gas": (
+            "GasCentreOfMass",
+            3,
+            np.float32,
+            "Mpc",
+            "Centre of mass of gas.",
+            "gas",
+            "DScale5",
+            False,
+        ),
+        "com_star": (
+            "StellarCentreOfMass",
+            3,
+            np.float32,
+            "Mpc",
+            "Centre of mass of stars.",
+            "star",
+            "DScale5",
+            False,
+        ),
+        "compY": (
+            "ComptonY",
+            1,
+            np.float64,
+            "cm**2",
+            "Total Compton y parameter.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "compY_no_agn": (
+            "ComptonYWithoutRecentAGNHeating",
+            1,
+            np.float64,
+            "cm**2",
+            "Total Compton y parameter. Excludes gas that was recently heated by AGN.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "kappa_corot_baryons": (
+            "KappaCorotBaryons",
+            1,
+            np.float32,
+            "dimensionless",
+            "Kappa-corot for baryons (gas and stars), relative to the centre of potential and the centre of mass velocity of the baryons.",
+            "baryon",
+            "FMantissa9",
+            False,
+        ),
+        "kappa_corot_gas": (
+            "KappaCorotGas",
+            1,
+            np.float32,
+            "dimensionless",
+            "Kappa-corot for gas, relative to the centre of potential and the centre of mass velocity of the gas.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "kappa_corot_star": (
+            "KappaCorotStars",
+            1,
+            np.float32,
+            "dimensionless",
+            "Kappa-corot for stars, relative to the centre of potential and the centre of mass velocity of the stars.",
+            "star",
+            "FMantissa9",
+            False,
+        ),
+        "proj_veldisp_dm": (
+            "DarkMatterProjectedVelocityDispersion",
+            1,
+            np.float32,
+            "km/s",
+            "Mass-weighted velocity dispersion of the DM along the projection axis, relative to the DM centre of mass velocity.",
+            "dm",
+            "FMantissa9",
+            True,
+        ),
+        "proj_veldisp_gas": (
+            "GasProjectedVelocityDispersion",
+            1,
+            np.float32,
+            "km/s",
+            "Mass-weighted velocity dispersion of the gas along the projection axis, relative to the gas centre of mass velocity.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "proj_veldisp_star": (
+            "StellarProjectedVelocityDispersion",
+            1,
+            np.float32,
+            "km/s",
+            "Mass-weighted velocity dispersion of the stars along the projection axis, relative to the stellar centre of mass velocity.",
+            "star",
+            "FMantissa9",
+            False,
+        ),
+        "r": (
+            "SORadius",
+            1,
+            np.float32,
+            "Mpc",
+            "Radius of a sphere {label}",
+            "basic",
+            "FMantissa9",
+            True,
+        ),
+        "spin_parameter": (
+            "SpinParameter",
+            1,
+            np.float32,
+            "dimensionless",
+            "Bullock et al. (2001) spin parameter.",
+            "general",
+            "FMantissa9",
+            True,
+        ),
+        "stellar_age_lw": (
+            "LuminosityWeightedMeanStellarAge",
+            1,
+            np.float32,
+            "Myr",
+            "Luminosity weighted mean stellar age. The weight is the r band luminosity.",
+            "star",
+            "FMantissa9",
+            False,
+        ),
+        "stellar_age_mw": (
+            "MassWeightedMeanStellarAge",
+            1,
+            np.float32,
+            "Myr",
+            "Mass weighted mean stellar age.",
+            "star",
+            "FMantissa9",
+            False,
+        ),
+        "vcom": (
+            "CentreOfMassVelocity",
+            3,
+            np.float32,
+            "km/s",
+            "Centre of mass velocity.",
+            "basic",
+            "DScale1",
+            True,
+        ),
+        "vcom_gas": (
+            "GasCentreOfMassVelocity",
+            3,
+            np.float32,
+            "km/s",
+            "Centre of mass velocity of gas.",
+            "gas",
+            "DScale1",
+            False,
+        ),
+        "vcom_star": (
+            "StellarCentreOfMassVelocity",
+            3,
+            np.float32,
+            "km/s",
+            "Centre of mass velocity of stars.",
+            "star",
+            "DScale1",
+            False,
+        ),
+        "veldisp_matrix_dm": (
+            "DarkMatterVelocityDispersionMatrix",
+            6,
+            np.float32,
+            "km**2/s**2",
+            "Mass-weighted velocity dispersion of the dark matter. Measured relative to the DM centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
+            "dm",
+            "FMantissa9",
+            True,
+        ),
+        "veldisp_matrix_gas": (
+            "GasVelocityDispersionMatrix",
+            6,
+            np.float32,
+            "km**2/s**2",
+            "Mass-weighted velocity dispersion of the gas. Measured relative to the gas centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
+            "gas",
+            "FMantissa9",
+            False,
+        ),
+        "veldisp_matrix_star": (
+            "StellarVelocityDispersionMatrix",
+            6,
+            np.float32,
+            "km**2/s**2",
+            "Mass-weighted velocity dispersion of the stars. Measured relative to the stellar centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
+            "star",
+            "FMantissa9",
+            False,
         ),
     }
 
@@ -984,6 +1084,7 @@ class PropertyTable:
             prop_description,
             prop_cat,
             prop_comp,
+            prop_dmo,
         ) in enumerate(props):
             prop_units = (
                 unyt.unyt_quantity(1, units=prop_units)
@@ -1036,6 +1137,7 @@ class PropertyTable:
                     "description": prop_description,
                     "category": prop_cat,
                     "compression": prop_comp,
+                    "dmo": prop_dmo,
                     "types": [halo_type],
                     "raw": props[i],
                 }
@@ -1053,10 +1155,11 @@ class PropertyTable:
                 raw_description,
                 raw_cat,
                 raw_comp,
+                raw_dmo,
             ) = self.properties[name]["raw"]
             raw_dtype = f"np.{raw_dtype.__name__}"
             print(
-                f'  "{raw_name}": ("{raw_outputname}", {raw_shape}, {raw_dtype}, "{raw_units}", "{raw_description}", "{raw_cat}", "{raw_comp}"),'
+                f'  "{raw_name}": ("{raw_outputname}", {raw_shape}, {raw_dtype}, "{raw_units}", "{raw_description}", "{raw_cat}", "{raw_comp}", {raw_dmo}),'
             )
         print("}")
 
@@ -1076,6 +1179,8 @@ class PropertyTable:
 \\usepackage{pdflscape}
 \\usepackage{a4wide}
 \\usepackage{multirow}
+\\usepackage{xcolor}
+
 \\begin{document}"""
 
         tablestr = """\\begin{landscape}
@@ -1109,33 +1214,31 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
                 checkmark if "ProjectedApertureProperties" in prop["types"] else xmark
             )
             prop_SO = checkmark if "SOProperties" in prop["types"] else xmark
+            table_props = [
+                prop_outputname,
+                prop_shape,
+                prop_dtype,
+                prop_units,
+                prop_subhalo,
+                prop_exclusive,
+                prop_inclusive,
+                prop_projected,
+                prop_SO,
+                prop_cat,
+                prop_comp,
+            ]
+            if prop["dmo"]:
+                print_table_props = [f"{{\\color{{violet}}{v}}}" for v in table_props]
+                prop_description = f"{{\\color{{violet}}{prop_description}}}"
+            else:
+                print_table_props = list(table_props)
             if prev_cat is None:
                 prev_cat = prop_cat
             if prop_cat != prev_cat:
                 prev_cat = prop_cat
                 tablestr += "\\hline{}"
-            tablestr += (
-                "\\rule{0pt}{4ex}"
-                + " & ".join(
-                    [
-                        v
-                        for v in [
-                            prop_outputname,
-                            prop_shape,
-                            prop_dtype,
-                            prop_units,
-                            prop_subhalo,
-                            prop_exclusive,
-                            prop_inclusive,
-                            prop_projected,
-                            prop_SO,
-                            prop_cat,
-                            prop_comp,
-                        ]
-                    ]
-                )
-                + "\\\\*\n"
-            )
+            tablestr += "\\rule{0pt}{4ex}"
+            tablestr += " & ".join([v for v in print_table_props]) + "\\\\*\n"
             tablestr += f"\\multicolumn{{10}}{{p{{20cm}}}}{{\\rule{{30pt}}{{0pt}}{prop_description}}}\\\\\n"
         tablestr += """\\end{longtable}
 \\end{landscape}"""

--- a/property_table.py
+++ b/property_table.py
@@ -6,7 +6,7 @@ import unyt
 
 class PropertyTable:
 
-    categories = ["basic", "general", "gas", "dm", "star", "baryon"]
+    categories = ["basic", "general", "gas", "dm", "star", "baryon", "VR"]
     explanation = {
         "footnote_MBH.tex": ["BHmaxM"],
         "footnote_com.tex": ["com", "vcom"],
@@ -64,6 +64,14 @@ class PropertyTable:
         "footnote_dopplerB.tex": ["DopplerB"],
     }
 
+    compression_description = {
+        "FMantissa9": "$1.36693{\\rm{}e}10 \\rightarrow{} 1.367{\\rm{}e}10$",
+        "DScale5": "10 pc accurate",
+        "DScale1": "0.1 km/s accurate",
+        "Nbit40": "Store less bits",
+        "None": "no compression",
+    }
+
     # List of properties that get computed
     # For each property, we have the following columns:
     #  - name: Name of the property within calculate() and in the output file
@@ -97,7 +105,7 @@ class PropertyTable:
             "dimensionless",
             "ID of most massive black hole.",
             "basic",
-            "FMantissa9",
+            "Nbit40",
         ),
         "BHmaxM": (
             "MostMassiveBlackHoleMass",
@@ -493,7 +501,7 @@ class PropertyTable:
             "dimensionless",
             "Number of black hole particles.",
             "basic",
-            "FMantissa9",
+            "None",
         ),
         "Ndm": (
             "NumberOfDarkMatterParticles",
@@ -502,7 +510,7 @@ class PropertyTable:
             "dimensionless",
             "Number of dark matter particles.",
             "basic",
-            "FMantissa9",
+            "None",
         ),
         "Ngas": (
             "NumberOfGasParticles",
@@ -511,7 +519,7 @@ class PropertyTable:
             "dimensionless",
             "Number of gas particles.",
             "basic",
-            "FMantissa9",
+            "None",
         ),
         "Nnu": (
             "NumberOfNeutrinoParticles",
@@ -520,7 +528,7 @@ class PropertyTable:
             "dimensionless",
             "Number of neutrino particles.",
             "basic",
-            "FMantissa9",
+            "None",
         ),
         "Nstar": (
             "NumberOfStarParticles",
@@ -529,7 +537,7 @@ class PropertyTable:
             "dimensionless",
             "Number of star particles.",
             "basic",
-            "FMantissa9",
+            "None",
         ),
         "ProjectedBaryonAxisLengths": (
             "ProjectedBaryonAxisLengths",
@@ -688,10 +696,10 @@ class PropertyTable:
             "CentreOfMass",
             3,
             np.float32,
-            "kpc",
+            "Mpc",
             "Centre of mass.",
             "basic",
-            "FMantissa9",
+            "DScale5",
         ),
         "com_gas": (
             "GasCentreOfMass",
@@ -700,7 +708,7 @@ class PropertyTable:
             "Mpc",
             "Centre of mass of gas.",
             "gas",
-            "FMantissa9",
+            "DScale5",
         ),
         "com_star": (
             "StellarCentreOfMass",
@@ -709,7 +717,7 @@ class PropertyTable:
             "Mpc",
             "Centre of mass of stars.",
             "star",
-            "FMantissa9",
+            "DScale5",
         ),
         "compY": (
             "ComptonY",
@@ -826,7 +834,7 @@ class PropertyTable:
             "km/s",
             "Centre of mass velocity.",
             "basic",
-            "FMantissa9",
+            "DScale1",
         ),
         "vcom_gas": (
             "GasCentreOfMassVelocity",
@@ -835,7 +843,7 @@ class PropertyTable:
             "km/s",
             "Centre of mass velocity of gas.",
             "gas",
-            "FMantissa9",
+            "DScale1",
         ),
         "vcom_star": (
             "StellarCentreOfMassVelocity",
@@ -844,7 +852,7 @@ class PropertyTable:
             "km/s",
             "Centre of mass velocity of stars.",
             "star",
-            "FMantissa9",
+            "DScale1",
         ),
         "veldisp_matrix_dm": (
             "DarkMatterVelocityDispersionMatrix",
@@ -872,6 +880,69 @@ class PropertyTable:
             "Mass-weighted velocity dispersion of the stars. Measured relative to the stellar centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
             "star",
             "FMantissa9",
+        ),
+        "VRID": (
+            "ID",
+            1,
+            np.uint64,
+            "dimensionless",
+            "ID assigned to this halo by VR.",
+            "VR",
+            "None",
+        ),
+        "VRindex": (
+            "Index",
+            1,
+            np.int64,
+            "dimensionless",
+            "Index of this halo in the original VR output.",
+            "VR",
+            "None",
+        ),
+        "VRHostHaloID": (
+            "HostHaloID",
+            1,
+            np.int64,
+            "dimensionless",
+            "VR/ID of the top level parent of this halo. -1 for field halos.",
+            "VR",
+            "None",
+        ),
+        "VRParentHaloID": (
+            "ParentHaloID",
+            1,
+            np.int64,
+            "dimensionless",
+            "VR/ID of the direct parent of this halo. -1 for field halos.",
+            "VR",
+            "None",
+        ),
+        "VRNumSubStruct": (
+            "NumberOfSubstructures",
+            1,
+            np.uint64,
+            "dimensionless",
+            "Number of sub-structures within this halo.",
+            "VR",
+            "None",
+        ),
+        "VRStructureType": (
+            "StructureType",
+            1,
+            np.int32,
+            "dimensionless",
+            "Structure type identified by VR. Field halos are 10, higher numbers are for satellites.",
+            "VR",
+            "None",
+        ),
+        "VRposition": (
+            "CentreOfPotential",
+            3,
+            np.float64,
+            "Mpc",
+            "Centre of potential, as identified by VR. Used as reference for all relative positions.",
+            "VR",
+            "DScale5",
         ),
     }
 
@@ -958,6 +1029,7 @@ class PropertyTable:
                     "units": prop_units,
                     "description": prop_description,
                     "category": prop_cat,
+                    "compression": prop_comp,
                     "types": [halo_type],
                     "raw": props[i],
                 }
@@ -1001,9 +1073,9 @@ class PropertyTable:
 \\begin{document}"""
 
         tablestr = """\\begin{landscape}
-\\begin{longtable}{llllllllll}
-Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category \\\\
-\\multicolumn{10}{l}{\\rule{30pt}{0pt}Description}\\\\
+\\begin{longtable}{lllllllllll}
+Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\\
+\\multicolumn{11}{l}{\\rule{30pt}{0pt}Description}\\\\
 \\hline{}\\endhead{}"""
         prev_cat = None
         for prop_name in prop_names:
@@ -1014,6 +1086,7 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category \\\\
             prop_dtype = prop["dtype"]
             prop_units = f'${prop["units"]}$' if prop["units"] != "" else "(no unit)"
             prop_cat = prop["category"]
+            prop_comp = self.compression_description[prop["compression"]]
             prop_description = prop["description"].format(
                 label="satisfying a spherical overdensity criterion."
             )
@@ -1051,6 +1124,7 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category \\\\
                             prop_projected,
                             prop_SO,
                             prop_cat,
+                            prop_comp,
                         ]
                     ]
                 )

--- a/property_table.py
+++ b/property_table.py
@@ -79,6 +79,7 @@ class PropertyTable:
             "dimensionless",
             "Scale-factor of last AGN event.",
             "general",
+            "FMantissa9",
         ),
         "BHmaxAR": (
             "MostMassiveBlackHoleAccretionRate",
@@ -87,6 +88,7 @@ class PropertyTable:
             "Msun/yr",
             "Gas accretion rate of most massive black hole.",
             "general",
+            "FMantissa9",
         ),
         "BHmaxID": (
             "MostMassiveBlackHoleID",
@@ -95,6 +97,7 @@ class PropertyTable:
             "dimensionless",
             "ID of most massive black hole.",
             "basic",
+            "FMantissa9",
         ),
         "BHmaxM": (
             "MostMassiveBlackHoleMass",
@@ -103,6 +106,7 @@ class PropertyTable:
             "Msun",
             "Mass of most massive black hole.",
             "basic",
+            "FMantissa9",
         ),
         "BHmaxlasteventa": (
             "MostMassiveBlackHoleLastEventScalefactor",
@@ -111,6 +115,7 @@ class PropertyTable:
             "dimensionless",
             "Scale-factor of last AGN event for most massive black hole.",
             "general",
+            "FMantissa9",
         ),
         "BHmaxpos": (
             "MostMassiveBlackHolePosition",
@@ -119,6 +124,7 @@ class PropertyTable:
             "kpc",
             "Position of most massive black hole.",
             "general",
+            "FMantissa9",
         ),
         "BHmaxvel": (
             "MostMassiveBlackHoleVelocity",
@@ -127,6 +133,7 @@ class PropertyTable:
             "km/s",
             "Velocity of most massive black hole relative to the simulation volume.",
             "general",
+            "FMantissa9",
         ),
         "BaryonAxisLengths": (
             "BaryonAxisLengths",
@@ -135,6 +142,7 @@ class PropertyTable:
             "kpc",
             "Axis lengths of the baryonic (gas and stars) mass distribution, computed from the 3D baryon inertia tensor, relative to the centre of potential.",
             "baryon",
+            "FMantissa9",
         ),
         "DMAxisLengths": (
             "DarkMatterAxisLengths",
@@ -143,22 +151,7 @@ class PropertyTable:
             "kpc",
             "Axis lengths of the dark matter mass distribution, computed from the 3D DM inertia tensor, relative to the centre of potential.",
             "dm",
-        ),
-        "DtoTstar": (
-            "DiscToTotalStellarMassFraction",
-            1,
-            np.float32,
-            "dimensionless",
-            "Fraction of the total stellar mass that is co-rotating.",
-            "star",
-        ),
-        "DtoTgas": (
-            "DiscToTotalGasMassFraction",
-            1,
-            np.float32,
-            "dimensionless",
-            "Fraction of the total gas mass that is co-rotating.",
-            "gas",
+            "FMantissa9",
         ),
         "DopplerB": (
             "DopplerB",
@@ -167,6 +160,25 @@ class PropertyTable:
             "dimensionless",
             "Kinetic Sunyaey-Zel'dovich effect, assuming a line of sight towards the position of the first lightcone observer.",
             "gas",
+            "FMantissa9",
+        ),
+        "DtoTgas": (
+            "DiscToTotalGasMassFraction",
+            1,
+            np.float32,
+            "dimensionless",
+            "Fraction of the total gas mass that is co-rotating.",
+            "gas",
+            "FMantissa9",
+        ),
+        "DtoTstar": (
+            "DiscToTotalStellarMassFraction",
+            1,
+            np.float32,
+            "dimensionless",
+            "Fraction of the total stellar mass that is co-rotating.",
+            "star",
+            "FMantissa9",
         ),
         "Ekin_gas": (
             "KineticEnergyGas",
@@ -175,6 +187,7 @@ class PropertyTable:
             "erg",
             "Total kinetic energy of the gas, relative to the gas centre of mass velocity.",
             "gas",
+            "FMantissa9",
         ),
         "Ekin_star": (
             "KineticEnergyStars",
@@ -183,6 +196,7 @@ class PropertyTable:
             "erg",
             "Total kinetic energy of the stars, relative to the stellar centre of mass velocity.",
             "star",
+            "FMantissa9",
         ),
         "Etherm_gas": (
             "ThermalEnergyGas",
@@ -191,6 +205,7 @@ class PropertyTable:
             "erg",
             "Total thermal energy of the gas.",
             "gas",
+            "FMantissa9",
         ),
         "GasAxisLengths": (
             "GasAxisLengths",
@@ -199,30 +214,7 @@ class PropertyTable:
             "kpc",
             "Axis lengths of the gas mass distribution, computed from the 3D gas inertia tensor, relative to the centre of potential.",
             "gas",
-        ),
-        "ProjectedGasAxisLengths": (
-            "ProjectedGasAxisLengths",
-            2,
-            np.float32,
-            "kpc",
-            "Axis lengths of the projected gas mass distribution, computed from the 2D gas inertia tensor, relative to the centre of potential.",
-            "gas",
-        ),
-        "ProjectedStellarAxisLengths": (
-            "ProjectedStellarAxisLengths",
-            2,
-            np.float32,
-            "kpc",
-            "Axis lengths of the projected stellar mass distribution, computed from the 2D stellar inertia tensor, relative to the centre of potential.",
-            "star",
-        ),
-        "ProjectedBaryonAxisLengths": (
-            "ProjectedBaryonAxisLengths",
-            2,
-            np.float32,
-            "kpc",
-            "Axis lengths of the projected baryon (gas and stars) mass distribution, computed from the 2D baryon inertia tensor, relative to the centre of potential.",
-            "baryon",
+            "FMantissa9",
         ),
         "HalfMassRadiusBaryon": (
             "HalfMassRadiusBaryons",
@@ -231,6 +223,7 @@ class PropertyTable:
             "kpc",
             "Baryonic (gas and stars) half mass radius.",
             "baryon",
+            "FMantissa9",
         ),
         "HalfMassRadiusDM": (
             "HalfMassRadiusDarkMatter",
@@ -239,6 +232,7 @@ class PropertyTable:
             "kpc",
             "Dark matter half mass radius.",
             "dm",
+            "FMantissa9",
         ),
         "HalfMassRadiusGas": (
             "HalfMassRadiusGas",
@@ -247,6 +241,7 @@ class PropertyTable:
             "kpc",
             "Gas half mass radius.",
             "gas",
+            "FMantissa9",
         ),
         "HalfMassRadiusStar": (
             "HalfMassRadiusStars",
@@ -255,6 +250,7 @@ class PropertyTable:
             "kpc",
             "Stellar half mass radius.",
             "star",
+            "FMantissa9",
         ),
         "HalfMassRadiusTot": (
             "HalfMassRadiusTotal",
@@ -263,6 +259,7 @@ class PropertyTable:
             "kpc",
             "Total half mass radius.",
             "general",
+            "FMantissa9",
         ),
         "Lbaryons": (
             "AngularMomentumBaryons",
@@ -271,6 +268,7 @@ class PropertyTable:
             "Msun*kpc*km/s",
             "Total angular momentum of baryons (gas and stars), relative to the centre of potential and baryonic centre of mass velocity.",
             "baryon",
+            "FMantissa9",
         ),
         "Ldm": (
             "AngularMomentumDarkMatter",
@@ -279,6 +277,7 @@ class PropertyTable:
             "Msun*kpc*km/s",
             "Total angular momentum of the dark matter, relative to the centre of potential and DM centre of mass velocity.",
             "dm",
+            "FMantissa9",
         ),
         "Lgas": (
             "AngularMomentumGas",
@@ -287,6 +286,7 @@ class PropertyTable:
             "Msun*kpc*km/s",
             "Total angular momentum of the gas, relative to the centre of potential and gas centre of mass velocity.",
             "gas",
+            "FMantissa9",
         ),
         "Lstar": (
             "AngularMomentumStars",
@@ -295,6 +295,7 @@ class PropertyTable:
             "Msun*kpc*km/s",
             "Total angular momentum of the stars, relative to the centre of potential and stellar centre of mass velocity.",
             "star",
+            "FMantissa9",
         ),
         "Mbh_dynamical": (
             "BlackHolesDynamicalMass",
@@ -303,6 +304,7 @@ class PropertyTable:
             "Msun",
             "Total BH dynamical mass.",
             "basic",
+            "FMantissa9",
         ),
         "Mbh_subgrid": (
             "BlackHolesSubgridMass",
@@ -311,8 +313,17 @@ class PropertyTable:
             "Msun",
             "Total BH subgrid mass.",
             "basic",
+            "FMantissa9",
         ),
-        "Mdm": ("DarkMatterMass", 1, np.float32, "Msun", "Total DM mass.", "basic"),
+        "Mdm": (
+            "DarkMatterMass",
+            1,
+            np.float32,
+            "Msun",
+            "Total DM mass.",
+            "basic",
+            "FMantissa9",
+        ),
         "Mfrac_satellites": (
             "MassFractionSatellites",
             1,
@@ -320,8 +331,17 @@ class PropertyTable:
             "dimensionless",
             "Fraction of mass that is bound to a satellite.",
             "general",
+            "FMantissa9",
         ),
-        "Mgas": ("GasMass", 1, np.float32, "Msun", "Total gas mass.", "basic"),
+        "Mgas": (
+            "GasMass",
+            1,
+            np.float32,
+            "Msun",
+            "Total gas mass.",
+            "basic",
+            "FMantissa9",
+        ),
         "MgasFe": (
             "GasMassInIron",
             1,
@@ -329,6 +349,7 @@ class PropertyTable:
             "Msun",
             "Total gas mass in iron.",
             "gas",
+            "FMantissa9",
         ),
         "MgasFe_SF": (
             "StarFormingGasMassInIron",
@@ -337,6 +358,7 @@ class PropertyTable:
             "Msun",
             "Total gas mass in iron for gas that is star-forming.",
             "gas",
+            "FMantissa9",
         ),
         "MgasO": (
             "GasMassInOxygen",
@@ -345,6 +367,7 @@ class PropertyTable:
             "Msun",
             "Total gas mass in oxygen.",
             "gas",
+            "FMantissa9",
         ),
         "MgasO_SF": (
             "StarFormingGasMassInOxygen",
@@ -353,6 +376,7 @@ class PropertyTable:
             "Msun",
             "Total gas mass in oxygen for gas that is star-forming.",
             "gas",
+            "FMantissa9",
         ),
         "Mgas_SF": (
             "StarFormingGasMass",
@@ -361,6 +385,7 @@ class PropertyTable:
             "Msun",
             "Total mass of star-forming gas.",
             "gas",
+            "FMantissa9",
         ),
         "Mgasmetal": (
             "GasMassInMetals",
@@ -369,6 +394,7 @@ class PropertyTable:
             "Msun",
             "Total gas mass in metals.",
             "gas",
+            "FMantissa9",
         ),
         "Mgasmetal_SF": (
             "StarFormingGasMassInMetals",
@@ -377,6 +403,7 @@ class PropertyTable:
             "Msun",
             "Total gas mass in metals for gas that is star-forming.",
             "gas",
+            "FMantissa9",
         ),
         "Mhotgas": (
             "HotGasMass",
@@ -385,6 +412,7 @@ class PropertyTable:
             "Msun",
             "Total mass of gas with a temperature above 1e5 K.",
             "gas",
+            "FMantissa9",
         ),
         "Mnu": (
             "RawNeutrinoMass",
@@ -393,6 +421,7 @@ class PropertyTable:
             "Msun",
             "Total neutrino particle mass.",
             "basic",
+            "FMantissa9",
         ),
         "MnuNS": (
             "NoiseSuppressedNeutrinoMass",
@@ -401,8 +430,17 @@ class PropertyTable:
             "Msun",
             "Noise suppressed total neutrino mass.",
             "basic",
+            "FMantissa9",
         ),
-        "Mstar": ("StellarMass", 1, np.float32, "Msun", "Total stellar mass.", "basic"),
+        "Mstar": (
+            "StellarMass",
+            1,
+            np.float32,
+            "Msun",
+            "Total stellar mass.",
+            "basic",
+            "FMantissa9",
+        ),
         "MstarFe": (
             "StellarMassInIron",
             1,
@@ -410,6 +448,7 @@ class PropertyTable:
             "Msun",
             "Total stellar mass in iron.",
             "star",
+            "FMantissa9",
         ),
         "MstarO": (
             "StellarMassInOxygen",
@@ -418,6 +457,7 @@ class PropertyTable:
             "Msun",
             "Total stellar mass in oxygen.",
             "star",
+            "FMantissa9",
         ),
         "Mstar_init": (
             "StellarInitialMass",
@@ -426,6 +466,7 @@ class PropertyTable:
             "Msun",
             "Total stellar initial mass.",
             "star",
+            "FMantissa9",
         ),
         "Mstarmetal": (
             "StellarMassInMetals",
@@ -434,8 +475,17 @@ class PropertyTable:
             "Msun",
             "Total stellar mass in metals.",
             "star",
+            "FMantissa9",
         ),
-        "Mtot": ("TotalMass", 1, np.float32, "Msun", "Total mass.", "basic"),
+        "Mtot": (
+            "TotalMass",
+            1,
+            np.float32,
+            "Msun",
+            "Total mass.",
+            "basic",
+            "FMantissa9",
+        ),
         "Nbh": (
             "NumberOfBlackHoleParticles",
             1,
@@ -443,6 +493,7 @@ class PropertyTable:
             "dimensionless",
             "Number of black hole particles.",
             "basic",
+            "FMantissa9",
         ),
         "Ndm": (
             "NumberOfDarkMatterParticles",
@@ -451,6 +502,7 @@ class PropertyTable:
             "dimensionless",
             "Number of dark matter particles.",
             "basic",
+            "FMantissa9",
         ),
         "Ngas": (
             "NumberOfGasParticles",
@@ -459,6 +511,7 @@ class PropertyTable:
             "dimensionless",
             "Number of gas particles.",
             "basic",
+            "FMantissa9",
         ),
         "Nnu": (
             "NumberOfNeutrinoParticles",
@@ -467,6 +520,7 @@ class PropertyTable:
             "dimensionless",
             "Number of neutrino particles.",
             "basic",
+            "FMantissa9",
         ),
         "Nstar": (
             "NumberOfStarParticles",
@@ -475,6 +529,34 @@ class PropertyTable:
             "dimensionless",
             "Number of star particles.",
             "basic",
+            "FMantissa9",
+        ),
+        "ProjectedBaryonAxisLengths": (
+            "ProjectedBaryonAxisLengths",
+            2,
+            np.float32,
+            "kpc",
+            "Axis lengths of the projected baryon (gas and stars) mass distribution, computed from the 2D baryon inertia tensor, relative to the centre of potential.",
+            "baryon",
+            "FMantissa9",
+        ),
+        "ProjectedGasAxisLengths": (
+            "ProjectedGasAxisLengths",
+            2,
+            np.float32,
+            "kpc",
+            "Axis lengths of the projected gas mass distribution, computed from the 2D gas inertia tensor, relative to the centre of potential.",
+            "gas",
+            "FMantissa9",
+        ),
+        "ProjectedStellarAxisLengths": (
+            "ProjectedStellarAxisLengths",
+            2,
+            np.float32,
+            "kpc",
+            "Axis lengths of the projected stellar mass distribution, computed from the 2D stellar inertia tensor, relative to the centre of potential.",
+            "star",
+            "FMantissa9",
         ),
         "R_vmax": (
             "MaximumCircularVelocityRadius",
@@ -483,6 +565,7 @@ class PropertyTable:
             "kpc",
             "Radius at which Vmax is reached.",
             "general",
+            "FMantissa9",
         ),
         "SFR": (
             "StarFormationRate",
@@ -491,6 +574,7 @@ class PropertyTable:
             "Msun/yr",
             "Total star formation rate.",
             "general",
+            "FMantissa9",
         ),
         "StellarAxisLengths": (
             "StellarAxisLengths",
@@ -499,6 +583,7 @@ class PropertyTable:
             "kpc",
             "Axis lengths of the stellar mass distribution, computed from the 3D stellar inertia tensor, relative to the centre of potential.",
             "star",
+            "FMantissa9",
         ),
         "StellarLuminosity": (
             "StellarLuminosity",
@@ -507,6 +592,7 @@ class PropertyTable:
             "dimensionless",
             "Total stellar luminosity in the 9 GAMA bands.",
             "star",
+            "FMantissa9",
         ),
         "Tgas": (
             "GasTemperature",
@@ -515,6 +601,7 @@ class PropertyTable:
             "K",
             "Mass-weighted mean gas temperature.",
             "gas",
+            "FMantissa9",
         ),
         "Tgas_no_agn": (
             "GasTemperatureWithoutRecentAGNHeating",
@@ -523,6 +610,7 @@ class PropertyTable:
             "K",
             "Mass-weighted mean gas temperature, excluding gas that was recently heated by AGN.",
             "gas",
+            "FMantissa9",
         ),
         "Tgas_no_cool": (
             "GasTemperatureWithoutCoolGas",
@@ -531,6 +619,7 @@ class PropertyTable:
             "K",
             "Mass-weighted mean gas temperature, excluding cool gas with a temperature below 1e5 K.",
             "gas",
+            "FMantissa9",
         ),
         "Tgas_no_cool_no_agn": (
             "GasTemperatureWithoutCoolGasAndRecentAGNHeating",
@@ -539,6 +628,7 @@ class PropertyTable:
             "K",
             "Mass-weighted mean gas temperature, excluding cool gas with a temperature below 1e5 K and gas that was recently heated by AGN.",
             "gas",
+            "FMantissa9",
         ),
         "TotalAxisLengths": (
             "TotalAxisLengths",
@@ -547,6 +637,7 @@ class PropertyTable:
             "kpc",
             "Axis lengths of the total mass distribution, computed from the 3D inertia tensor, relative to the centre of potential.",
             "general",
+            "FMantissa9",
         ),
         "Vmax": (
             "MaximumCircularVelocity",
@@ -555,6 +646,7 @@ class PropertyTable:
             "km/s",
             "Maximum circular velocity.",
             "general",
+            "FMantissa9",
         ),
         "Xraylum": (
             "XRayLuminosity",
@@ -563,6 +655,7 @@ class PropertyTable:
             "erg/s",
             "Total rest-frame Xray luminosity in three bands.",
             "gas",
+            "FMantissa9",
         ),
         "Xraylum_no_agn": (
             "XRayLuminosityWithoutRecentAGNHeating",
@@ -571,6 +664,7 @@ class PropertyTable:
             "erg/s",
             "Total rest-frame Xray luminosity in three bands. Excludes gas that was recently heated by AGN.",
             "gas",
+            "FMantissa9",
         ),
         "Xrayphlum": (
             "XRayPhotonLuminosity",
@@ -579,6 +673,7 @@ class PropertyTable:
             "1/s",
             "Total rest-frame Xray photon luminosity in three bands.",
             "gas",
+            "FMantissa9",
         ),
         "Xrayphlum_no_agn": (
             "XRayPhotonLuminosityWithoutRecentAGNHeating",
@@ -587,8 +682,17 @@ class PropertyTable:
             "1/s",
             "Total rest-frame Xray photon luminosity in three bands. Exclude gas that was recently heated by AGN.",
             "gas",
+            "FMantissa9",
         ),
-        "com": ("CentreOfMass", 3, np.float32, "kpc", "Centre of mass.", "basic"),
+        "com": (
+            "CentreOfMass",
+            3,
+            np.float32,
+            "kpc",
+            "Centre of mass.",
+            "basic",
+            "FMantissa9",
+        ),
         "com_gas": (
             "GasCentreOfMass",
             3,
@@ -596,6 +700,7 @@ class PropertyTable:
             "Mpc",
             "Centre of mass of gas.",
             "gas",
+            "FMantissa9",
         ),
         "com_star": (
             "StellarCentreOfMass",
@@ -604,6 +709,7 @@ class PropertyTable:
             "Mpc",
             "Centre of mass of stars.",
             "star",
+            "FMantissa9",
         ),
         "compY": (
             "ComptonY",
@@ -612,6 +718,7 @@ class PropertyTable:
             "cm**2",
             "Total Compton y parameter.",
             "gas",
+            "FMantissa9",
         ),
         "compY_no_agn": (
             "ComptonYWithoutRecentAGNHeating",
@@ -620,6 +727,7 @@ class PropertyTable:
             "cm**2",
             "Total Compton y parameter. Excludes gas that was recently heated by AGN.",
             "gas",
+            "FMantissa9",
         ),
         "kappa_corot_baryons": (
             "KappaCorotBaryons",
@@ -628,6 +736,7 @@ class PropertyTable:
             "dimensionless",
             "Kappa-corot for baryons (gas and stars), relative to the centre of potential and the centre of mass velocity of the baryons.",
             "baryon",
+            "FMantissa9",
         ),
         "kappa_corot_gas": (
             "KappaCorotGas",
@@ -636,6 +745,7 @@ class PropertyTable:
             "dimensionless",
             "Kappa-corot for gas, relative to the centre of potential and the centre of mass velocity of the gas.",
             "gas",
+            "FMantissa9",
         ),
         "kappa_corot_star": (
             "KappaCorotStars",
@@ -644,6 +754,7 @@ class PropertyTable:
             "dimensionless",
             "Kappa-corot for stars, relative to the centre of potential and the centre of mass velocity of the stars.",
             "star",
+            "FMantissa9",
         ),
         "proj_veldisp_dm": (
             "DarkMatterProjectedVelocityDispersion",
@@ -652,6 +763,7 @@ class PropertyTable:
             "km/s",
             "Mass-weighted velocity dispersion of the DM along the projection axis, relative to the DM centre of mass velocity.",
             "dm",
+            "FMantissa9",
         ),
         "proj_veldisp_gas": (
             "GasProjectedVelocityDispersion",
@@ -660,6 +772,7 @@ class PropertyTable:
             "km/s",
             "Mass-weighted velocity dispersion of the gas along the projection axis, relative to the gas centre of mass velocity.",
             "gas",
+            "FMantissa9",
         ),
         "proj_veldisp_star": (
             "StellarProjectedVelocityDispersion",
@@ -668,8 +781,17 @@ class PropertyTable:
             "km/s",
             "Mass-weighted velocity dispersion of the stars along the projection axis, relative to the stellar centre of mass velocity.",
             "star",
+            "FMantissa9",
         ),
-        "r": ("SORadius", 1, np.float32, "Mpc", "Radius of a sphere {label}", "basic"),
+        "r": (
+            "SORadius",
+            1,
+            np.float32,
+            "Mpc",
+            "Radius of a sphere {label}",
+            "basic",
+            "FMantissa9",
+        ),
         "spin_parameter": (
             "SpinParameter",
             1,
@@ -677,62 +799,7 @@ class PropertyTable:
             "dimensionless",
             "Bullock et al. (2001) spin parameter.",
             "general",
-        ),
-        "vcom": (
-            "CentreOfMassVelocity",
-            3,
-            np.float32,
-            "km/s",
-            "Centre of mass velocity.",
-            "basic",
-        ),
-        "vcom_gas": (
-            "GasCentreOfMassVelocity",
-            3,
-            np.float32,
-            "km/s",
-            "Centre of mass velocity of gas.",
-            "gas",
-        ),
-        "vcom_star": (
-            "StellarCentreOfMassVelocity",
-            3,
-            np.float32,
-            "km/s",
-            "Centre of mass velocity of stars.",
-            "star",
-        ),
-        "veldisp_matrix_dm": (
-            "DarkMatterVelocityDispersionMatrix",
-            6,
-            np.float32,
-            "km**2/s**2",
-            "Mass-weighted velocity dispersion of the dark matter. Measured relative to the DM centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
-            "dm",
-        ),
-        "veldisp_matrix_gas": (
-            "GasVelocityDispersionMatrix",
-            6,
-            np.float32,
-            "km**2/s**2",
-            "Mass-weighted velocity dispersion of the gas. Measured relative to the gas centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
-            "gas",
-        ),
-        "veldisp_matrix_star": (
-            "StellarVelocityDispersionMatrix",
-            6,
-            np.float32,
-            "km**2/s**2",
-            "Mass-weighted velocity dispersion of the stars. Measured relative to the stellar centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
-            "star",
-        ),
-        "stellar_age_mw": (
-            "MassWeightedMeanStellarAge",
-            1,
-            np.float32,
-            "Myr",
-            "Mass weighted mean stellar age.",
-            "star",
+            "FMantissa9",
         ),
         "stellar_age_lw": (
             "LuminosityWeightedMeanStellarAge",
@@ -741,6 +808,70 @@ class PropertyTable:
             "Myr",
             "Luminosity weighted mean stellar age. The weight is the r band luminosity.",
             "star",
+            "FMantissa9",
+        ),
+        "stellar_age_mw": (
+            "MassWeightedMeanStellarAge",
+            1,
+            np.float32,
+            "Myr",
+            "Mass weighted mean stellar age.",
+            "star",
+            "FMantissa9",
+        ),
+        "vcom": (
+            "CentreOfMassVelocity",
+            3,
+            np.float32,
+            "km/s",
+            "Centre of mass velocity.",
+            "basic",
+            "FMantissa9",
+        ),
+        "vcom_gas": (
+            "GasCentreOfMassVelocity",
+            3,
+            np.float32,
+            "km/s",
+            "Centre of mass velocity of gas.",
+            "gas",
+            "FMantissa9",
+        ),
+        "vcom_star": (
+            "StellarCentreOfMassVelocity",
+            3,
+            np.float32,
+            "km/s",
+            "Centre of mass velocity of stars.",
+            "star",
+            "FMantissa9",
+        ),
+        "veldisp_matrix_dm": (
+            "DarkMatterVelocityDispersionMatrix",
+            6,
+            np.float32,
+            "km**2/s**2",
+            "Mass-weighted velocity dispersion of the dark matter. Measured relative to the DM centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
+            "dm",
+            "FMantissa9",
+        ),
+        "veldisp_matrix_gas": (
+            "GasVelocityDispersionMatrix",
+            6,
+            np.float32,
+            "km**2/s**2",
+            "Mass-weighted velocity dispersion of the gas. Measured relative to the gas centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
+            "gas",
+            "FMantissa9",
+        ),
+        "veldisp_matrix_star": (
+            "StellarVelocityDispersionMatrix",
+            6,
+            np.float32,
+            "km**2/s**2",
+            "Mass-weighted velocity dispersion of the stars. Measured relative to the stellar centre of mass velocity. The order of the components of the dispersion tensor is XX YY ZZ XY XZ YZ.",
+            "star",
+            "FMantissa9",
         ),
     }
 
@@ -775,6 +906,7 @@ class PropertyTable:
             prop_units,
             prop_description,
             prop_cat,
+            prop_comp,
         ) in enumerate(props):
             prop_units = (
                 unyt.unyt_quantity(1, units=prop_units)
@@ -836,15 +968,17 @@ class PropertyTable:
         for name in names:
             (
                 raw_name,
+                raw_outputname,
                 raw_shape,
                 raw_dtype,
                 raw_units,
                 raw_description,
                 raw_cat,
+                raw_comp,
             ) = self.properties[name]["raw"]
             raw_dtype = f"np.{raw_dtype.__name__}"
             print(
-                f'  "{raw_name}": ("{raw_name}", {raw_shape}, {raw_dtype}, "{raw_units}", "{raw_description}", "{raw_cat}"),'
+                f'  "{raw_name}": ("{raw_outputname}", {raw_shape}, {raw_dtype}, "{raw_units}", "{raw_description}", "{raw_cat}", "{raw_comp}"),'
             )
         print("}")
 

--- a/property_table.py
+++ b/property_table.py
@@ -899,7 +899,7 @@ class PropertyTable:
             "VR",
             "None",
         ),
-        "VRHostHaloID": (
+        "VRhostHaloID": (
             "HostHaloID",
             1,
             np.int64,
@@ -908,7 +908,7 @@ class PropertyTable:
             "VR",
             "None",
         ),
-        "VRParentHaloID": (
+        "VRParent_halo_ID": (
             "ParentHaloID",
             1,
             np.int64,
@@ -917,7 +917,7 @@ class PropertyTable:
             "VR",
             "None",
         ),
-        "VRNumSubStruct": (
+        "VRnumSubStruct": (
             "NumberOfSubstructures",
             1,
             np.uint64,
@@ -926,7 +926,7 @@ class PropertyTable:
             "VR",
             "None",
         ),
-        "VRStructureType": (
+        "VRStructuretype": (
             "StructureType",
             1,
             np.int32,
@@ -935,7 +935,7 @@ class PropertyTable:
             "VR",
             "None",
         ),
-        "VRposition": (
+        "VRcofp": (
             "CentreOfPotential",
             3,
             np.float64,
@@ -945,6 +945,12 @@ class PropertyTable:
             "DScale5",
         ),
     }
+
+    # we should really use removeprefix("VR") instead of [2:], but that only
+    # exists since Python 3.9
+    vr_properties = [
+        vrname[2:] for vrname in full_property_list.keys() if vrname.startswith("VR")
+    ]
 
     def get_footnotes(self, name):
         footnotes = []

--- a/scripts/FLAMINGO/L2800N5040/group_membership_L2800N5040.sh
+++ b/scripts/FLAMINGO/L2800N5040/group_membership_L2800N5040.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -l
+#
+# Compute VR group membership for each particle in a snapshot.
+# Job name determines which of the L2800N5040 runs we process.
+# Array job index is the snapshot number to do.
+#
+# Submit with (for example):
+#
+# sbatch -J HYDRO_FIDUCIAL --array=78 ./group_membership_L2800N5040.sh
+#
+#SBATCH --nodes=16
+#SBATCH --cpus-per-task=1
+#SBATCH -o ./logs/group_membership_L2800N5040_%x.%a.out
+#SBATCH -p cosma8
+#SBATCH -A dp004
+#SBATCH --exclusive
+#SBATCH -t 72:00:00
+#
+
+module purge
+module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
+
+# Which snapshot to do
+snapnum=`printf '%04d' ${SLURM_ARRAY_TASK_ID}`
+
+# Which simulation to do
+sim="L2800N5040/${SLURM_JOB_NAME}"
+
+# Input simulation location
+basedir="/cosma8/data/dp004/flamingo/Runs/${sim}/"
+
+# Where to write the output
+outbase="/snap8/scratch/dp004/jch/FLAMINGO/ScienceRuns/${sim}/"
+
+# Generate input and output file names
+swift_filename="${basedir}/snapshots/flamingo_${snapnum}/flamingo_${snapnum}.%(file_nr)d.hdf5"
+vr_basename="${basedir}/VR/catalogue_${snapnum}/vr_catalogue_${snapnum}"
+outfile="${outbase}/group_membership/group_membership_${snapnum}/vr_membership_${snapnum}.%(file_nr)d.hdf5"
+
+# Create output directory
+outdir=`dirname "${outfile}"`
+mkdir -p "${outdir}"
+lfs setstripe --stripe-count=-1 --stripe-size=32M ${outdir}
+
+# Copy virtual file
+#cp "${basedir}/snapshots/flamingo_${snapnum}/flamingo_${snapnum}.hdf5" ${outdir}
+#vfile_out=${outdir}/flamingo_${snapnum}.hdf5
+#chmod u+w ${vfile_out}
+
+mpirun python3 -u -m mpi4py \
+    ./vr_group_membership.py ${swift_filename} ${vr_basename} ${outfile}
+
+ #--update-virtual-file=${vfile_out}

--- a/scripts/FLAMINGO/L2800N5040/halo_properties_L2800N5040.sh
+++ b/scripts/FLAMINGO/L2800N5040/halo_properties_L2800N5040.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -l
+#
+# Compute halo properties for a snapshot. Must run the group_membership
+# script first.
+#
+# Job name determines which of the L2800N5040 runs we process.
+# Array job index is the snapshot number to do. Submit with (for example):
+#
+# sbatch -J HYDRO_FIDUCIAL --array=78 ./halo_properties_L2800N5040.sh
+#
+#SBATCH --nodes=16
+#SBATCH --cpus-per-task=1
+#SBATCH -J test_halo_props
+#SBATCH -o ./logs/halo_properties_L2800N5040_%x.%a.out
+#SBATCH -p cosma8
+#SBATCH -A dp004
+#SBATCH --exclusive
+#SBATCH -t 72:00:00
+#
+
+module purge
+module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
+
+# Which simulation to do
+sim="L2800N5040/${SLURM_JOB_NAME}"
+
+# Input simulation location
+basedir="/cosma8/data/dp004/flamingo/Runs/${sim}/"
+
+# Where to write the final output
+outbase="/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/"
+
+# Location for temporary chunk output
+scratchdir="/snap8/scratch/dp004/jch/SOAP-tmp/${sim}/"
+
+# Generate file names for this snapshot
+swift_filename="${basedir}/snapshots/flamingo_%(snap_nr)04d/flamingo_%(snap_nr)04d.%(file_nr)d.hdf5"
+extra_filename="${outbase}/group_membership/group_membership_%(snap_nr)04d/vr_membership_%(snap_nr)04d.%(file_nr)d.hdf5"
+vr_basename="${basedir}/VR/catalogue_%(snap_nr)04d/vr_catalogue_%(snap_nr)04d"
+outfile="${outbase}/halo_properties/halo_properties_%(snap_nr)04d.hdf5"
+
+nr_chunks=80
+
+# Create output directory
+outdir=`dirname "${outfile}"`
+mkdir -p "${outdir}"
+
+mpirun python3 -u -m mpi4py ./compute_halo_properties.py \
+    ${swift_filename} ${scratchdir} ${vr_basename} ${outfile} ${SLURM_ARRAY_TASK_ID} \
+    --chunks=${nr_chunks} \
+    --extra-input=${extra_filename}

--- a/stellar_age_calculator.py
+++ b/stellar_age_calculator.py
@@ -1,0 +1,75 @@
+#!/bin/env python
+
+import numpy as np
+import unyt
+
+from astropy.cosmology import w0waCDM, z_at_value
+import astropy.constants as const
+import astropy.units as astropy_units
+
+
+class StellarAgeCalculator:
+    """
+    Auxiliary object used to calculate stellar ages.
+
+    Since the snapshots contain the stellar birth scale factor, obtaining the
+    stellar age requires knowledge about the simulation cosmology.
+
+    Upon construction, we extract the relevant cosmology and the current scale
+    factor from the cellgrid to create a convenient function that can directly
+    calculate the stellar age from the stellar birth scale factor.
+    """
+
+    def __init__(
+        self,
+        cellgrid,
+    ):
+        H0 = unyt.unyt_quantity(
+            cellgrid.cosmology["H0 [internal units]"],
+            units="1/snap_time",
+            registry=cellgrid.snap_unit_registry,
+        ).to("1/s")
+
+        Omega_b = cellgrid.cosmology["Omega_b"]
+        Omega_lambda = cellgrid.cosmology["Omega_lambda"]
+        Omega_r = cellgrid.cosmology["Omega_r"]
+        Omega_m = cellgrid.cosmology["Omega_m"]
+        w_0 = cellgrid.cosmology["w_0"]
+        w_a = cellgrid.cosmology["w_a"]
+        z_now = cellgrid.cosmology["Redshift"]
+
+        # expressions taken directly from astropy, since they do no longer
+        # allow access to these attributes (since version 5.1+)
+        critdens_const = (3.0 / (8.0 * np.pi * const.G)).cgs.value
+        a_B_c2 = (4.0 * const.sigma_sb / const.c**3).cgs.value
+
+        # SWIFT provides Omega_r, but we need a consistent Tcmb0 for astropy.
+        # This is an exact inversion of the procedure performed in astropy.
+        critical_density_0 = astropy_units.Quantity(
+            critdens_const * H0.to("1/s").value ** 2,
+            astropy_units.g / astropy_units.cm**3,
+        )
+
+        Tcmb0 = (Omega_r * critical_density_0.value / a_B_c2) ** (1.0 / 4.0)
+
+        self.cosmology = w0waCDM(
+            H0=H0.to_astropy(),
+            Om0=Omega_m,
+            Ode0=Omega_lambda,
+            w0=w_0,
+            wa=w_a,
+            Tcmb0=Tcmb0,
+            Ob0=Omega_b,
+        )
+
+        self.t_now = unyt.unyt_quantity.from_astropy(
+            self.cosmology.lookback_time(z_now)
+        ).to("Myr")
+
+    def stellar_age(self, birth_a):
+        birth_z = 1.0 / birth_a - 1.0
+        t_birth = unyt.unyt_array.from_astropy(
+            self.cosmology.lookback_time(birth_z.value)
+        ).to("Myr")
+        # remember: we use lookback time, which runs backwards!
+        return t_birth - self.t_now

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -191,7 +191,7 @@ class SubhaloProperties(HaloProperty):
         # all variables are defined with physical units and an appropriate dtype
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
-        for name, _, shape, dtype, unit, _, _ in self.property_list:
+        for name, _, shape, dtype, unit, _, _, _ in self.property_list:
             if shape > 1:
                 val = [0] * shape
             else:
@@ -428,7 +428,7 @@ class SubhaloProperties(HaloProperty):
             prefix = "BoundSubhaloProperties"
         else:
             prefix = "FOFSubhaloProperties"
-        for name, outputname, _, _, _, description, _ in self.property_list:
+        for name, outputname, _, _, _, description, _, _ in self.property_list:
             halo_result.update(
                 {
                     f"{prefix}/{outputname}": (
@@ -492,6 +492,7 @@ def test_subhalo_properties():
                 size,
                 dtype,
                 unit_string,
+                _,
                 _,
                 _,
             ) in prop_calc.property_list:

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -870,7 +870,12 @@ class SubhaloProperties(HaloProperty):
         # we need to use the custom unit registry so that everything can be converted
         # back to snapshot units in the end
         registry = part_props.mass.units.registry
-        for name, _, shape, dtype, unit, _, category, _ in self.property_list:
+        for prop in self.property_list:
+            name = prop[0]
+            shape = prop[2]
+            dtype = prop[3]
+            unit = prop[4]
+            category = prop[6]
             if shape > 1:
                 val = [0] * shape
             else:
@@ -896,7 +901,10 @@ class SubhaloProperties(HaloProperty):
             prefix = "BoundSubhaloProperties"
         else:
             prefix = "FOFSubhaloProperties"
-        for name, outputname, _, _, _, description, _, _ in self.property_list:
+        for prop in self.property_list:
+            name = prop[0]
+            outputname = prop[1]
+            description = prop[5]
             halo_result.update(
                 {
                     f"{prefix}/{outputname}": (
@@ -963,16 +971,11 @@ def test_subhalo_properties():
             assert input_data == input_data_copy
 
             # check that the calculation returns the correct values
-            for (
-                _,
-                outputname,
-                size,
-                dtype,
-                unit_string,
-                _,
-                _,
-                _,
-            ) in prop_calc.property_list:
+            for prop in prop_calc.property_list:
+                outputname = prop[1]
+                size = prop[2]
+                dtype = prop[3]
+                unit_string = prop[4]
                 full_name = f"{subhalo_name}/{outputname}"
                 assert full_name in halo_result
                 result = halo_result[full_name][0]

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -76,6 +76,8 @@ class SubhaloProperties(HaloProperty):
             "veldisp_matrix_star",
             "DtoTgas",
             "DtoTstar",
+            "stellar_age_mw",
+            "stellar_age_lw",
         ]
     ]
 

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -200,26 +200,38 @@ class SubhaloParticleData:
 
     @lazy_property
     def star_mask_all(self):
+        if self.Nstar == 0:
+            return None
         return self.data["PartType4"][self.grnr] == self.index
 
     @lazy_property
     def mass_star_init(self):
+        if self.Nstar == 0:
+            return None
         return self.data["PartType4"]["InitialMasses"][self.star_mask_all]
 
     @lazy_property
     def Mstar_init(self):
+        if self.Nstar == 0:
+            return None
         return self.mass_star_init.sum()
 
     @lazy_property
     def stellar_luminosities(self):
+        if self.Nstar == 0:
+            return None
         return self.data["PartType4"]["Luminosities"][self.star_mask_all]
 
     @lazy_property
     def StellarLuminosity(self):
+        if self.Nstar == 0:
+            return None
         return self.stellar_luminosities.sum(axis=0)
 
     @lazy_property
     def Mstarmetal(self):
+        if self.Nstar == 0:
+            return None
         return (
             self.mass_star
             * self.data["PartType4"]["MetalMassFractions"][self.star_mask_all]
@@ -227,91 +239,131 @@ class SubhaloParticleData:
 
     @lazy_property
     def stellar_ages(self):
+        if self.Nstar == 0:
+            return None
         birth_a = self.data["PartType4"]["BirthScaleFactors"][self.star_mask_all]
         return self.stellar_age_calculator.stellar_age(birth_a)
 
     @lazy_property
     def stellar_age_mw(self):
+        if self.Nstar == 0:
+            return None
         return ((self.mass_star / self.Mstar) * self.stellar_ages).sum()
 
     @lazy_property
     def stellar_age_lw(self):
+        if self.Nstar == 0:
+            return None
         Lr = self.stellar_luminosities[:, rbandindex]
         Lrtot = Lr.sum()
         return ((Lr / Lrtot) * self.stellar_ages).sum()
 
     @lazy_property
     def bh_mask_all(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"][self.grnr] == self.index
 
     @lazy_property
     def Mbh_subgrid(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"]["SubgridMasses"][self.bh_mask_all].sum()
 
     @lazy_property
     def agn_eventa(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"]["LastAGNFeedbackScaleFactors"][self.bh_mask_all]
 
     @lazy_property
     def BHlasteventa(self):
+        if self.Nbh == 0:
+            return None
         return np.max(self.agn_eventa)
 
     @lazy_property
     def iBHmax(self):
+        if self.Nbh == 0:
+            return None
         return np.argmax(self.data["PartType5"]["SubgridMasses"][self.bh_mask_all])
 
     @lazy_property
     def BHmaxM(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"]["SubgridMasses"][self.bh_mask_all][self.iBHmax]
 
     @lazy_property
     def BHmaxID(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"]["ParticleIDs"][self.bh_mask_all][self.iBHmax]
 
     @lazy_property
     def BHmaxpos(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"]["Coordinates"][self.bh_mask_all][self.iBHmax]
 
     @lazy_property
     def BHmaxvel(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"]["Velocities"][self.bh_mask_all][self.iBHmax]
 
     @lazy_property
     def BHmaxAR(self):
+        if self.Nbh == 0:
+            return None
         return self.data["PartType5"]["AccretionRates"][self.bh_mask_all][self.iBHmax]
 
     @lazy_property
     def BHmaxlasteventa(self):
+        if self.Nbh == 0:
+            return None
         return self.agn_eventa[self.iBHmax]
 
     @lazy_property
     def total_mass_fraction(self):
+        if self.Mtot == 0:
+            return None
         return self.mass / self.Mtot
 
     @lazy_property
     def com(self):
+        if self.Mtot == 0:
+            return None
         return (self.total_mass_fraction[:, None] * self.position).sum(
             axis=0
         ) + self.centre
 
     @lazy_property
     def vcom(self):
+        if self.Mtot == 0:
+            return None
         return (self.total_mass_fraction[:, None] * self.velocity).sum(axis=0)
 
     @lazy_property
     def R_vmax(self):
+        if self.Mtot == 0:
+            return None
         if not hasattr(self, "r_vmax"):
             self.r_vmax, self.vmax = get_vmax(self.mass, self.radius)
         return self.r_vmax
 
     @lazy_property
     def Vmax(self):
+        if self.Mtot == 0:
+            return None
         if not hasattr(self, "vmax"):
             self.r_vmax, self.vmax = get_vmax(self.mass, self.radius)
         return self.vmax
 
     @lazy_property
     def spin_parameter(self):
+        if self.Mtot == 0:
+            return None
         if self.R_vmax > 0 and self.Vmax > 0:
             mask_r_vmax = self.radius <= self.R_vmax
             vrel = self.velocity[mask_r_vmax, :] - self.vcom[None, :]
@@ -332,10 +384,14 @@ class SubhaloParticleData:
 
     @lazy_property
     def gas_mass_fraction(self):
+        if self.Mgas == 0:
+            return None
         return self.mass_gas / self.Mgas
 
     @lazy_property
     def vcom_gas(self):
+        if self.Mgas == 0:
+            return None
         return (self.gas_mass_fraction[:, None] * self.vel_gas).sum(axis=0)
 
     def compute_Lgas_props(self):
@@ -353,18 +409,24 @@ class SubhaloParticleData:
 
     @lazy_property
     def Lgas(self):
+        if self.Mgas == 0:
+            return None
         if not hasattr(self, "internal_Lgas"):
             self.compute_Lgas_props()
         return self.internal_Lgas
 
     @lazy_property
     def kappa_corot_gas(self):
+        if self.Mgas == 0:
+            return None
         if not hasattr(self, "internal_kappa_gas"):
             self.compute_Lgas_props()
         return self.internal_kappa_gas
 
     @lazy_property
     def DtoTgas(self):
+        if self.Mgas == 0:
+            return None
         if not hasattr(self, "internal_Mcountrot_gas"):
             self.compute_Lgas_props()
         return 1.0 - 2.0 * self.internal_Mcountrot_gas / self.Mgas
@@ -375,20 +437,28 @@ class SubhaloParticleData:
 
     @lazy_property
     def veldisp_matrix_gas(self):
+        if self.Mgas == 0:
+            return None
         return get_velocity_dispersion_matrix(
             self.gas_mass_fraction, self.vel_gas, self.vcom_gas
         )
 
     @lazy_property
     def dm_mass_fraction(self):
+        if self.Mdm == 0:
+            return None
         return self.mass_dm / self.Mdm
 
     @lazy_property
     def vcom_dm(self):
+        if self.Mdm == 0:
+            return None
         return (self.dm_mass_fraction[:, None] * self.vel_dm).sum(axis=0)
 
     @lazy_property
     def Ldm(self):
+        if self.Mdm == 0:
+            return None
         return get_angular_momentum(
             self.mass_dm, self.pos_dm, self.vel_dm, ref_velocity=self.vcom_dm
         )
@@ -399,16 +469,22 @@ class SubhaloParticleData:
 
     @lazy_property
     def veldisp_matrix_dm(self):
+        if self.Mdm == 0:
+            return None
         return get_velocity_dispersion_matrix(
             self.dm_mass_fraction, self.vel_dm, self.vcom_dm
         )
 
     @lazy_property
     def star_mass_fraction(self):
+        if self.Mstar == 0:
+            return None
         return self.mass_star / self.Mstar
 
     @lazy_property
     def vcom_star(self):
+        if self.Mstar == 0:
+            return None
         return (self.star_mass_fraction[:, None] * self.vel_star).sum(axis=0)
 
     def compute_Lstar_props(self):
@@ -426,18 +502,24 @@ class SubhaloParticleData:
 
     @lazy_property
     def Lstar(self):
+        if self.Mstar == 0:
+            return None
         if not hasattr(self, "internal_Lstar"):
             self.compute_Lstar_props()
         return self.internal_Lstar
 
     @lazy_property
     def kappa_corot_star(self):
+        if self.Mstar == 0:
+            return None
         if not hasattr(self, "internal_kappa_star"):
             self.compute_Lstar_props()
         return self.internal_kappa_star
 
     @lazy_property
     def DtoTstar(self):
+        if self.Mstar == 0:
+            return None
         if not hasattr(self, "internal_Mcountrot_star"):
             self.compute_Lstar_props()
         return 1.0 - 2.0 * self.internal_Mcountrot_star / self.Mstar
@@ -448,16 +530,26 @@ class SubhaloParticleData:
 
     @lazy_property
     def veldisp_matrix_star(self):
+        if self.Mstar == 0:
+            return None
         return get_velocity_dispersion_matrix(
             self.star_mass_fraction, self.vel_star, self.vcom_star
         )
 
     @lazy_property
+    def Mbaryon(self):
+        return self.Mgas + self.Mstar
+
+    @lazy_property
     def baryon_mass_fraction(self):
-        return self.mass_baryons / (self.Mgas + self.Mstar)
+        if self.Mbaryon == 0:
+            return None
+        return self.mass_baryons / self.Mbaryon
 
     @lazy_property
     def vcom_bar(self):
+        if self.Mbaryon == 0:
+            return None
         return (self.baryon_mass_fraction[:, None] * self.vel_baryons).sum(axis=0)
 
     def compute_Lbar_props(self):
@@ -473,12 +565,16 @@ class SubhaloParticleData:
 
     @lazy_property
     def Lbaryons(self):
+        if self.Mbaryon == 0:
+            return None
         if not hasattr(self, "internal_Lbar"):
             self.compute_Lbar_props()
         return self.internal_Lbar
 
     @lazy_property
     def kappa_corot_baryons(self):
+        if self.Mbaryon == 0:
+            return None
         if not hasattr(self, "internal_kappa_bar"):
             self.compute_Lbar_props()
         return self.internal_kappa_bar
@@ -493,11 +589,15 @@ class SubhaloParticleData:
 
     @lazy_property
     def SFR(self):
+        if self.Ngas == 0:
+            return None
         all_SFR = self.data["PartType0"]["StarFormationRates"][self.gas_mask_all]
         return all_SFR[all_SFR > 0.0].sum()
 
     @lazy_property
     def Mgasmetal(self):
+        if self.Ngas == 0:
+            return None
         return (
             self.mass_gas
             * self.data["PartType0"]["MetalMassFractions"][self.gas_mask_all]
@@ -505,28 +605,40 @@ class SubhaloParticleData:
 
     @lazy_property
     def gas_temp(self):
+        if self.Ngas == 0:
+            return None
         return self.data["PartType0"]["Temperatures"][self.gas_mask_all]
 
     @lazy_property
     def last_agn_gas(self):
+        if self.Ngas == 0:
+            return None
         return self.data["PartType0"]["LastAGNFeedbackScaleFactors"][self.gas_mask_all]
 
     @lazy_property
     def gas_no_agn(self):
+        if self.Ngas == 0:
+            return None
         return ~self.recently_heated_gas_filter.is_recently_heated(
             self.last_agn_gas, self.gas_temp
         )
 
     @lazy_property
     def gas_no_cool(self):
+        if self.Ngas == 0:
+            return None
         return self.gas_temp >= 1.0e5 * unyt.K
 
     @lazy_property
     def Tgas(self):
+        if self.Ngas == 0:
+            return None
         return (self.gas_mass_fraction * self.gas_temp).sum()
 
     @lazy_property
     def Tgas_no_cool(self):
+        if self.Ngas == 0:
+            return None
         if np.any(self.gas_no_cool):
             mass_gas_no_cool = self.mass_gas[self.gas_no_cool]
             Mgas_no_cool = mass_gas_no_cool.sum()
@@ -538,6 +650,8 @@ class SubhaloParticleData:
 
     @lazy_property
     def Tgas_no_agn(self):
+        if self.Ngas == 0:
+            return None
         if np.any(self.gas_no_agn):
             mass_gas_no_agn = self.mass_gas[self.gas_no_agn]
             Mgas_no_agn = mass_gas_no_agn.sum()
@@ -549,6 +663,8 @@ class SubhaloParticleData:
 
     @lazy_property
     def Tgas_no_cool_no_agn(self):
+        if self.Ngas == 0:
+            return None
         no_cool_no_agn = self.gas_no_agn & self.gas_no_cool
         if np.any(no_cool_no_agn):
             mass_gas_no_cool_no_agn = self.mass_gas[no_cool_no_agn]
@@ -763,80 +879,14 @@ class SubhaloProperties(HaloProperty):
             subhalo[name] = unyt.unyt_array(
                 val, dtype=dtype, units=unit, registry=part_props.mass.units.registry
             )
-
-        set_halo_property(subhalo, "Ngas", part_props)
-        set_halo_property(subhalo, "Ndm", part_props)
-        set_halo_property(subhalo, "Nstar", part_props)
-        set_halo_property(subhalo, "Nbh", part_props)
-
-        set_halo_property(subhalo, "Mtot", part_props)
-        set_halo_property(subhalo, "Mgas", part_props)
-        set_halo_property(subhalo, "Mdm", part_props)
-        set_halo_property(subhalo, "Mstar", part_props)
-        set_halo_property(subhalo, "Mbh_dynamical", part_props)
-
-        if part_props.Nstar > 0:
-            set_halo_property(subhalo, "Mstar_init", part_props)
-            set_halo_property(subhalo, "StellarLuminosity", part_props)
-            set_halo_property(subhalo, "Mstarmetal", part_props)
-            set_halo_property(subhalo, "stellar_age_mw", part_props)
-            set_halo_property(subhalo, "stellar_age_lw", part_props)
-
-        if part_props.Nbh > 0:
-            set_halo_property(subhalo, "Mbh_subgrid", part_props)
-            set_halo_property(subhalo, "BHlasteventa", part_props)
-            set_halo_property(subhalo, "BHmaxM", part_props)
-            set_halo_property(subhalo, "BHmaxID", part_props)
-            set_halo_property(subhalo, "BHmaxpos", part_props)
-            set_halo_property(subhalo, "BHmaxvel", part_props)
-            set_halo_property(subhalo, "BHmaxAR", part_props)
-            set_halo_property(subhalo, "BHmaxlasteventa", part_props)
-
-        if part_props.Mtot > 0:
-            set_halo_property(subhalo, "com", part_props)
-            set_halo_property(subhalo, "vcom", part_props)
-            set_halo_property(subhalo, "R_vmax", part_props)
-            set_halo_property(subhalo, "Vmax", part_props)
-            set_halo_property(subhalo, "spin_parameter", part_props)
-            set_halo_property(subhalo, "TotalAxisLengths", part_props)
-
-        if part_props.Mgas > 0:
-            set_halo_property(subhalo, "Lgas", part_props)
-            set_halo_property(subhalo, "kappa_corot_gas", part_props)
-            set_halo_property(subhalo, "DtoTgas", part_props)
-            set_halo_property(subhalo, "GasAxisLengths", part_props)
-            set_halo_property(subhalo, "veldisp_matrix_gas", part_props)
-
-        if part_props.Mdm > 0:
-            set_halo_property(subhalo, "Ldm", part_props)
-            set_halo_property(subhalo, "DMAxisLengths", part_props)
-            set_halo_property(subhalo, "veldisp_matrix_dm", part_props)
-
-        if part_props.Mstar > 0:
-            set_halo_property(subhalo, "Lstar", part_props)
-            set_halo_property(subhalo, "kappa_corot_star", part_props)
-            set_halo_property(subhalo, "DtoTstar", part_props)
-            set_halo_property(subhalo, "StellarAxisLengths", part_props)
-            set_halo_property(subhalo, "veldisp_matrix_star", part_props)
-
-        if part_props.Mgas + part_props.Mstar > 0:
-            set_halo_property(subhalo, "Lbaryons", part_props)
-            set_halo_property(subhalo, "kappa_corot_baryons", part_props)
-            set_halo_property(subhalo, "BaryonAxisLengths", part_props)
-
-        if part_props.Ngas > 0:
-            set_halo_property(subhalo, "SFR", part_props)
-            set_halo_property(subhalo, "Mgasmetal", part_props)
-            set_halo_property(subhalo, "Tgas", part_props)
-            set_halo_property(subhalo, "Tgas_no_cool", part_props)
-            set_halo_property(subhalo, "Tgas_no_agn", part_props)
-            set_halo_property(subhalo, "Tgas_no_cool_no_agn", part_props)
-
-        set_halo_property(subhalo, "HalfMassRadiusTot", part_props)
-        set_halo_property(subhalo, "HalfMassRadiusGas", part_props)
-        set_halo_property(subhalo, "HalfMassRadiusDM", part_props)
-        set_halo_property(subhalo, "HalfMassRadiusStar", part_props)
-        set_halo_property(subhalo, "HalfMassRadiusBaryon", part_props)
+            val = getattr(part_props, name)
+            if val is not None:
+                if unit == "dimensionless":
+                    subhalo[name] = unyt.unyt_array(
+                        val.astype(dtype), dtype=dtype, units=unit
+                    )
+                else:
+                    subhalo[name] += val
 
         # Add these properties to the output
         if self.bound_only:

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -871,6 +871,10 @@ class SubhaloProperties(HaloProperty):
         # back to snapshot units in the end
         registry = part_props.mass.units.registry
         for prop in self.property_list:
+            # skip non-DMO properties in DMO run mode
+            is_dmo = prop[8]
+            if do_calculation["DMO"] and not is_dmo:
+                continue
             name = prop[0]
             shape = prop[2]
             dtype = prop[3]
@@ -902,6 +906,9 @@ class SubhaloProperties(HaloProperty):
         else:
             prefix = "FOFSubhaloProperties"
         for prop in self.property_list:
+            is_dmo = prop[8]
+            if do_calculation["DMO"] and not is_dmo:
+                continue
             name = prop[0]
             outputname = prop[1]
             description = prop[5]

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -20,20 +20,6 @@ from property_table import PropertyTable
 rbandindex = 2
 
 
-def set_halo_property(property_dict, property_name, part_data):
-    property_info = PropertyTable.full_property_list[property_name]
-    dtype = property_info[2]
-    units = property_info[3]
-    property_value = getattr(part_data, property_name)
-    if property_value is not None:
-        if units == "dimensionless":
-            property_dict[property_name] = unyt.unyt_array(
-                property_value.astype(dtype), dtype=dtype, units=units
-            )
-        else:
-            property_dict[property_name] += property_value
-
-
 def lazy_property(fn):
     attr_name = "_lazy_" + fn.__name__
 

--- a/subhalo_properties.py
+++ b/subhalo_properties.py
@@ -353,6 +353,8 @@ class SubhaloParticleData:
 
     @lazy_property
     def TotalAxisLengths(self):
+        if self.Mtot == 0:
+            return None
         return get_axis_lengths(self.mass, self.position)
 
     @lazy_property
@@ -406,6 +408,8 @@ class SubhaloParticleData:
 
     @lazy_property
     def GasAxisLengths(self):
+        if self.Mgas == 0:
+            return None
         return get_axis_lengths(self.mass_gas, self.pos_gas)
 
     @lazy_property
@@ -438,6 +442,8 @@ class SubhaloParticleData:
 
     @lazy_property
     def DMAxisLengths(self):
+        if self.Mdm == 0:
+            return None
         return get_axis_lengths(self.mass_dm, self.pos_dm)
 
     @lazy_property
@@ -499,6 +505,8 @@ class SubhaloParticleData:
 
     @lazy_property
     def StellarAxisLengths(self):
+        if self.Mstar == 0:
+            return None
         return get_axis_lengths(self.mass_star, self.pos_star)
 
     @lazy_property
@@ -554,6 +562,8 @@ class SubhaloParticleData:
 
     @lazy_property
     def BaryonAxisLengths(self):
+        if self.Mbaryon == 0:
+            return None
         return get_axis_lengths(self.mass_baryons, self.pos_baryons)
 
     @lazy_property


### PR DESCRIPTION
This PR adds

 - a lossy compression filter field to the property table
 - mass- and luminosity-weighted stellar ages
 - some missing VR properties
 - VR properties are now also in the property table and their output name and description are read from that table for consistency
 - lazy evaluation of all property calculations: expensive expressions are only evaluated if the result is actually used
 - category based filtering of property calculations: properties are only calculated if the number of particles in the VR 6D FOF is above some configurable threshold
 - DMO support: new runtime argument to SOAP that disables the calculation and output of properties, based on a flag in the property table

Note that this PR also fixes an issue with the calculation of the SO stellar luminosities: the total luminosity sum accidentally ran over the whole array instead of the columns, so all SO luminosity values would have been the same (and too high) before.