### PR TITLE
Avoid gathering metadata from all chunks and MPI ranks

### DIFF
--- a/chunk_tasks.py
+++ b/chunk_tasks.py
@@ -335,7 +335,7 @@ class ChunkTask:
 
         # Return the names, dimensions and units of the quantities we computed
         # so that we can check they're consistent between chunks
-        return results.get_metadata()
+        return results.get_metadata(comm)
 
     @classmethod
     def bcast(cls, comm, instance):


### PR DESCRIPTION
Each chunk task now checks that all ranks on the node agree on the quantities computed. Only the first rank on the node returns the list of quantities. At the end of the calculation each node checks the results of the chunks it processed for consistency. Then each node sends its list of quantities to rank 0 in comm_world to check that all nodes agree.

This avoids the large allgather operation that was causing problems in the 2.8Gpc FLAMINGO box.