### PR TITLE
Filter fix and compression metadata

### DIFF
--- a/SO_properties.py
+++ b/SO_properties.py
@@ -81,32 +81,20 @@ def find_SO_radius_and_mass(
     # Compute a mask that marks particles above the threshold. We do this
     # exactly once.
     above_mask = density > reference_density
-    if np.any(above_mask):
+    if above_mask[0]:
         # Get the complementary mask of particles below the threshold.
         # By using the complementary, we avoid any ambiguity about '>' vs '<='
         below_mask = ~above_mask
         # Find smallest radius where the density is below the threshold
         i = np.argmax(below_mask)
         if i == 0:
-            if below_mask[i]:
-                # we know that there are points above the threshold
-                # unfortunately, the centre is not
-                # find the next one that is:
-                offset = np.argmax(above_mask)
-                # now get the next point below the threshold relative w.r.t. this point
-                i = np.argmax(below_mask[offset:])
-                # +offset because i is now relative w.r.t. offset
-                i += offset
-            else:
-                # 'i==0' can also mean no particles are below the threshold
-                # in this case, we need to increase the search radius
-                if ordered_radius[-1] > 20.0 * unyt.Mpc:
-                    raise RuntimeError(
-                        "Cannot find SO radius, but search radius is already larger than 20 Mpc!"
-                    )
-                raise ReadRadiusTooSmallError(
-                    "SO radius multiple estimate was too small!"
+            # There are no particles below the threshold
+            # We need to increase the search radius
+            if ordered_radius[-1] > 20.0 * unyt.Mpc:
+                raise RuntimeError(
+                    "Cannot find SO radius, but search radius is already larger than 20 Mpc!"
                 )
+            raise ReadRadiusTooSmallError("SO radius multiple estimate was too small!")
     else:
         # all non-zero radius particles are below the threshold
         # we linearly interpolate the mass from 0 to the particle radius

--- a/category_filter.py
+++ b/category_filter.py
@@ -58,6 +58,17 @@ class CategoryFilter:
             Nbh = halo_result[bh_filter_name][0].value
         return self.get_filters_direct(Ngas, Ndm, Nstar, Nbh)
 
+    def get_compression_metadata(self, property_output_name):
+        base_output_name = property_output_name.split("/")[-1]
+        compression = None
+        for _, prop in PropertyTable.full_property_list.items():
+            if prop[0] == base_output_name:
+                compression = prop[6]
+        if compression is None:
+            return {"Lossy Compression Algorithm": "None", "Is Compressed": False}
+        else:
+            return {"Lossy Compression Algorithm": compression, "Is Compressed": False}
+
     def get_filter_metadata(self, property_output_name):
         base_output_name = property_output_name.split("/")[-1]
         category = None

--- a/category_filter.py
+++ b/category_filter.py
@@ -38,11 +38,11 @@ class CategoryFilter:
     def get_filters_direct(self, Ngas, Ndm, Nstar, Nbh):
         return {
             "basic": True,
-            "general": Ngas + Ndm + Nstar + Nbh > self.Ngeneral,
-            "gas": Ngas > self.Ngas,
-            "dm": Ndm > self.Ndm,
-            "star": Nstar > self.Nstar,
-            "baryon": Ngas + Nstar > self.Nbaryon,
+            "general": Ngas + Ndm + Nstar + Nbh >= self.Ngeneral,
+            "gas": Ngas >= self.Ngas,
+            "dm": Ndm >= self.Ndm,
+            "star": Nstar >= self.Nstar,
+            "baryon": Ngas + Nstar >= self.Nbaryon,
             "DMO": self.dmo,
         }
 

--- a/combine_chunks.py
+++ b/combine_chunks.py
@@ -66,6 +66,8 @@ def combine_chunks(args, cellgrid, halo_prop_list, scratch_file_format,
                 attrs["Description"] = description
                 mask_metadata = category_filter.get_filter_metadata(name)
                 attrs.update(mask_metadata)
+                compression_metadata = category_filter.get_compression_metadata(name)
+                attrs.update(compression_metadata)
                 for attr_name, attr_value in attrs.items():
                     dataset.attrs[attr_name] = attr_value
             outfile.close()

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -11,11 +11,13 @@
 
 \title{SOAP -- Spherical Overdensity and Aperture Processor}
 \author{Bert Vandenbroucke, Joop Schaye, John Helly, Matthieu Schaller}
-\date{August 2022}
+\date{}
 
 \begin{document}
 
 \maketitle
+
+\input{timestamp}
 
 \section{Introduction}
 

--- a/documentation/SOAP.tex
+++ b/documentation/SOAP.tex
@@ -133,11 +133,11 @@ The different categories are summarised in the table below.
 \begin{longtable}{ll}
 Name & criterion \\
 \hline{}basic & (all halos) \\
-general & $N_{\rm{}gas}+N_{\rm{}dm}+N_{\rm{}star}+N_{\rm{}BH} > 100$ \\
-gas & $N_{\rm{}gas} > 50$ \\
-dm & $N_{\rm{}dm} > 100$ \\
-star & $N_{\rm{}star} > 50$ \\
-baryon & $N_{\rm{}gas}+N_{\rm{}star} > 100$ \\
+general & $N_{\rm{}gas}+N_{\rm{}dm}+N_{\rm{}star}+N_{\rm{}BH} \geq{} 100$ \\
+gas & $N_{\rm{}gas} \geq{} 100$ \\
+dm & $N_{\rm{}dm} \geq{} 100$ \\
+star & $N_{\rm{}star} \geq{} 100$ \\
+baryon & $N_{\rm{}gas}+N_{\rm{}star} \geq{} 100$ \\
 \end{longtable}
 
 \section{Overview table}
@@ -149,6 +149,10 @@ Superscript numbers refer to more detailed explanations for some of the properti
 the next section. The properties at the end of the table that are categorised as `VR' correspond to properties 
 that are directly copied from the VR catalogue and are only listed for completeness. These do not belong to 
 any type. Properties colored violet are also computed when SOAP is run in dark matter only (DMO) mode.
+
+Note that all units are always physical, and that the SOAP output contains all the relevant meta-data to 
+convert between physical and co-moving units, i.e. information about how the quantity depends on the 
+scale-factor and what the conversion factor to and from CGS units is. All quantities are $h$-free.
 
 \input{table}
 
@@ -171,7 +175,7 @@ inconsistent, in the sense that the condition
 is not guaranteed to be true, and will be especially violated for large radial bins (the bins are generated 
 from the particle radii by sorting the particles, so we have no control over their width). We instead opt to 
 guarantee this condition by only finding $R_{\rm{}SO}$ or $M_{\rm{}SO}$ by interpolation and using eq. 
-\ref{eq:MSO_condition} to derive the other quantity.
+(\ref{eq:MSO_condition}) to derive the other quantity.
 
 \begin{figure}
     \centering
@@ -220,25 +224,22 @@ For clarity, this is the full set of rules for determining the SO radius in SOAP
     \begin{enumerate}
         \item If there are none, analytically compute $R_{\rm{}SO}=\sqrt{3M_1/(4\pi{}R_1\rho_{\rm{}target})}$, 
         where $R_1$ and $M_1$ are the first non zero radius and the corresponding cumulative mass. This is a 
-        special case of Eq. \ref{eq:RSO}. Unless there are multiple particles at the exact centre of potential 
+        special case of Eq. (\ref{eq:RSO}). Unless there are multiple particles at the exact centre of potential 
         position, this radius estimate will then be based on just two particles.
-        \item If the first intersection point has a positive slope, i.e. the density was actually below the 
-        threshold in the centre, we use the next intersection point, which then necessarily should have a 
-        negative slope (if such a point does not exist, we need to increase the search radius).
-        \item In all other cases, we use $R_{1,2}$ and $M_{1,2}$ as input for Eq. \ref{eq:RSO} and solve for 
+        \item In all other cases, we use $R_{1,2}$ and $M_{1,2}$ as input for Eq. (\ref{eq:RSO}) and solve for 
         $R_{\rm{}SO}$. The only exception is the special case where $R_1 = R_2$. If that happens, we simply 
         move further down the line until we find a suitable interval.
 
     \end{enumerate}
-    \item From $R_{\rm{}SO}$, we determine $M_{\rm{}SO}$ using Eq. \ref{eq:MSO_condition}.
+    \item From $R_{\rm{}SO}$, we determine $M_{\rm{}SO}$ using Eq. (\ref{eq:MSO_condition}).
 \end{enumerate}
 
-\paragraph{Neutrinos are included} in the inclusive sphere calculation (and only here, since neutrino 
-particles cannot be bound to a halo) by adding both their weighted masses (which can be negative), as well as 
-the contribution from the background neutrino density. The latter is achieved by explicitly adding the 
-cumulative mass profile at constant neutrino density to the total cumulative mass profile before computing the 
-density profile. This is the only place where neutrinos explicitly enter the algorithm, except for the 
-neutrino masses computed for the SOs. Neutrinos are not included in the calculation of the centre of mass and 
-centre of mass velocity.
+\paragraph{Neutrinos -- if present in the model -- are included} in the inclusive sphere calculation (and only 
+here, since neutrino particles cannot be bound to a halo) by adding both their weighted masses (which can be 
+negative), as well as the contribution from the background neutrino density. The latter is achieved by 
+explicitly adding the cumulative mass profile at constant neutrino density to the total cumulative mass 
+profile before computing the density profile. This is the only place where neutrinos explicitly enter the 
+algorithm, except for the neutrino masses computed for the SOs. Neutrinos are not included in the calculation 
+of the centre of mass and centre of mass velocity.
 
 \end{document}

--- a/property_table.py
+++ b/property_table.py
@@ -88,6 +88,7 @@ class PropertyTable:
 
     compression_description = {
         "FMantissa9": "$1.36693{\\rm{}e}10 \\rightarrow{} 1.367{\\rm{}e}10$",
+        "DMantissa9": "$1.36693{\\rm{}e}10 \\rightarrow{} 1.367{\\rm{}e}10$",
         "DScale5": "10 pc accurate",
         "DScale1": "0.1 km/s accurate",
         "Nbit40": "Store less bits",
@@ -163,7 +164,7 @@ class PropertyTable:
             "kpc",
             "Position of most massive black hole.",
             "general",
-            "FMantissa9",
+            "DScale5",
             False,
         ),
         "BHmaxvel": (
@@ -233,7 +234,7 @@ class PropertyTable:
             "erg",
             "Total kinetic energy of the gas, relative to the gas centre of mass velocity.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "Ekin_star": (
@@ -243,7 +244,7 @@ class PropertyTable:
             "erg",
             "Total kinetic energy of the stars, relative to the stellar centre of mass velocity.",
             "star",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "Etherm_gas": (
@@ -253,7 +254,7 @@ class PropertyTable:
             "erg",
             "Total thermal energy of the gas.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "GasAxisLengths": (
@@ -843,7 +844,7 @@ class PropertyTable:
             "erg/s",
             "Total rest-frame Xray luminosity in three bands.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "Xraylum_no_agn": (
@@ -853,7 +854,7 @@ class PropertyTable:
             "erg/s",
             "Total rest-frame Xray luminosity in three bands. Excludes gas that was recently heated by AGN.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "Xrayphlum": (
@@ -863,7 +864,7 @@ class PropertyTable:
             "1/s",
             "Total rest-frame Xray photon luminosity in three bands.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "Xrayphlum_no_agn": (
@@ -873,7 +874,7 @@ class PropertyTable:
             "1/s",
             "Total rest-frame Xray photon luminosity in three bands. Exclude gas that was recently heated by AGN.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "com": (
@@ -913,7 +914,7 @@ class PropertyTable:
             "cm**2",
             "Total Compton y parameter.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "compY_no_agn": (
@@ -923,7 +924,7 @@ class PropertyTable:
             "cm**2",
             "Total Compton y parameter. Excludes gas that was recently heated by AGN.",
             "gas",
-            "FMantissa9",
+            "DMantissa9",
             False,
         ),
         "kappa_corot_baryons": (

--- a/property_table.py
+++ b/property_table.py
@@ -2,6 +2,22 @@
 
 import numpy as np
 import unyt
+import subprocess
+import datetime
+import os
+
+
+def get_version_string():
+    handle = subprocess.run("git describe --always", shell=True, stdout=subprocess.PIPE)
+    if handle.returncode != 0:
+        git_version = "Unknown SOAP version"
+    else:
+        git_version = handle.stdout.decode("utf-8").strip()
+        git_version = f"SOAP version ``{git_version}''"
+    timestamp = datetime.datetime.now().strftime("%A %-d %B %Y, %H:%M:%S")
+    username = os.getlogin()
+    hostname = os.uname().nodename
+    return f"{git_version} -- Compiled by user ``{username}'' on {hostname} on {timestamp}."
 
 
 class PropertyTable:
@@ -1189,7 +1205,7 @@ class PropertyTable:
             )
         print("}")
 
-    def print_table(self, tablefile, footnotefile):
+    def print_table(self, tablefile, footnotefile, timestampfile):
         prop_names = sorted(
             self.properties.keys(),
             key=lambda key: (
@@ -1269,6 +1285,8 @@ Name & Shape & Type & Units & SH & ES & IS & EP & SO & Category & Compression\\\
         tablestr += """\\end{longtable}
 \\end{landscape}"""
         tailstr = "\\end{document}"
+        with open(timestampfile, "w") as ofile:
+            ofile.write(get_version_string())
         with open(tablefile, "w") as ofile:
             ofile.write(tablestr)
         with open(footnotefile, "w") as ofile:
@@ -1305,4 +1323,8 @@ if __name__ == "__main__":
     if False:
         table.print_dictionary()
     else:
-        table.print_table("documentation/table.tex", "documentation/footnotes.tex")
+        table.print_table(
+            "documentation/table.tex",
+            "documentation/footnotes.tex",
+            "documentation/timestamp.tex",
+        )

--- a/property_table.py
+++ b/property_table.py
@@ -765,7 +765,7 @@ class PropertyTable:
             3,
             np.float64,
             "Mpc",
-            "Centre of potential, as identified by VR. Used as reference for all relative positions.",
+            "Centre of potential, as identified by VR. Used as reference for all relative positions. Equal to the position of the most bound particle in the subhalo.",
             "VR",
             "DScale5",
             True,


### PR DESCRIPTION
This PR fixes an issue when applying the category filter: the filter was using `>` rather than `>=` and was also excluding halos with exactly the threshold number of particles, which is counter intuitive.

I have also added two additional attributes to each dataset: `Lossy Compression Filter` and `Is Compressed`. The compression script can use (and update) those to apply the correct compression in post-processing.